### PR TITLE
binarylog.proto: clarify semantics about half-closure and call end

### DIFF
--- a/grpc/binlog/v1alpha/binarylog.proto
+++ b/grpc/binlog/v1alpha/binarylog.proto
@@ -28,6 +28,9 @@ message GrpcLogEntry {
   enum Type {
     UNKNOWN_TYPE = 0;
     SEND_INITIAL_METADATA = 1;
+    // On server side, a SERVER_CANCEL can still happen after sending
+    // trailers.
+    // On client side, this is means the client has half closed.
     SEND_TRAILING_METADATA = 2;
     SEND_MESSAGE = 3;
     RECV_INITIAL_METADATA = 4;

--- a/grpc/binlog/v1alpha/binarylog.proto
+++ b/grpc/binlog/v1alpha/binarylog.proto
@@ -37,7 +37,7 @@ message GrpcLogEntry {
     RECV_MESSAGE = 6;
     // Client side only.
     CLIENT_SEND_CANCEL = 7;
-    // Server side only. This is the last event for server side.
+    // Server side only. This means the RPC has now ended.
     SERVER_END_CALL = 8;
   };
 

--- a/grpc/binlog/v1alpha/binarylog.proto
+++ b/grpc/binlog/v1alpha/binarylog.proto
@@ -31,8 +31,14 @@ message GrpcLogEntry {
     SEND_TRAILING_METADATA = 2;
     SEND_MESSAGE = 3;
     RECV_INITIAL_METADATA = 4;
+    // On server side, this event means the client has half-closed.
+    // On client side, this is means the RPC has now ended.
     RECV_TRAILING_METADATA = 5;
     RECV_MESSAGE = 6;
+    // Client side only.
+    CLIENT_SEND_CANCEL = 7;
+    // Server side only. This is the last event for server side.
+    SERVER_END_CALL = 8;
   };
 
   // Enumerates the entity that generates the log entry
@@ -40,6 +46,17 @@ message GrpcLogEntry {
     UNKNOWN_LOGGER = 0;
     CLIENT = 1;
     SERVER = 2;
+  }
+
+  // On server side, SEND_TRAILING_METADATA does not end the call
+  // because the client can still cancel the call.  This enum shows
+  // the way the call actually ended.
+  enum ServerCallEnd {
+    UNKNOWN_END = 0;
+    // The call ended normally
+    NORMAL = 1;
+    // The call ended abnormally
+    ABNORMAL = 2;
   }
 
   Type type = 1;      // One of the above Type enum
@@ -64,6 +81,9 @@ message GrpcLogEntry {
 
   // true if payload does not represent the full message or metadata.
   bool truncated = 7;
+
+  // For SERVER_END_CALL only.
+  ServerCallEnd server_end = 8;
 };
 
 // Message payload, used by REQUEST and RESPONSE

--- a/grpc/binlog/v1alpha/binarylog.proto
+++ b/grpc/binlog/v1alpha/binarylog.proto
@@ -38,12 +38,8 @@ message GrpcLogEntry {
     // On client side, this is means the RPC has now ended.
     RECV_TRAILING_METADATA = 5;
     RECV_MESSAGE = 6;
-    // Client side only.
-    CLIENT_SEND_CANCEL = 7;
-    // Server side only. The RPC was cancalled, which may happen when
-    // a RST stream is received (client cancellation), a server side
-    // deadline is exceeded, an IO error occurred, etc.
-    SERVER_CANCEL = 8;
+    // The RPC is cancelled.
+    CANCEL = 7;
     // Server side only. This means the RPC has now ended. On server
     // side, SEND_TRAILING_METADATA is not necessarily the end of the
     // RPC, because a SERVER_CANCEL can still happen. A SERVER_END

--- a/grpc/binlog/v1alpha/binarylog.proto
+++ b/grpc/binlog/v1alpha/binarylog.proto
@@ -37,8 +37,16 @@ message GrpcLogEntry {
     RECV_MESSAGE = 6;
     // Client side only.
     CLIENT_SEND_CANCEL = 7;
-    // Server side only. This means the RPC has now ended.
-    SERVER_END_CALL = 8;
+    // Server side only. The RPC was cancalled, which may happen when
+    // a RST stream is received (client cancellation), a server side
+    // deadline is exceeded, an IO error occurred, etc.
+    SERVER_CANCEL = 8;
+    // Server side only. This means the RPC has now ended. On server
+    // side, SEND_TRAILING_METADATA is not necessarily the end of the
+    // RPC, because a SERVER_CANCEL can still happen. A SERVER_END
+    // marks the end of the RPC. This is not needed for client side
+    // because RECV_TRAILING_METADATA is always the last entry.
+    SERVER_END = 9;
   };
 
   // Enumerates the entity that generates the log entry
@@ -46,17 +54,6 @@ message GrpcLogEntry {
     UNKNOWN_LOGGER = 0;
     CLIENT = 1;
     SERVER = 2;
-  }
-
-  // On server side, SEND_TRAILING_METADATA does not end the call
-  // because the client can still cancel the call.  This enum shows
-  // the way the call actually ended.
-  enum ServerCallEnd {
-    UNKNOWN_END = 0;
-    // The call ended normally
-    NORMAL = 1;
-    // The call ended abnormally
-    ABNORMAL = 2;
   }
 
   Type type = 1;      // One of the above Type enum
@@ -81,9 +78,6 @@ message GrpcLogEntry {
 
   // true if payload does not represent the full message or metadata.
   bool truncated = 7;
-
-  // For SERVER_END_CALL only.
-  ServerCallEnd server_end = 8;
 };
 
 // Message payload, used by REQUEST and RESPONSE


### PR DESCRIPTION
This refines the proto to capture information about half closure and cancellations.