### PR TITLE
binarylog: move required info from metadata to top level fields

### DIFF
--- a/grpc/binlog/v1alpha/binarylog.proto
+++ b/grpc/binlog/v1alpha/binarylog.proto
@@ -52,7 +52,13 @@ message GrpcLogEntry {
   // The logger uses one of the following fields to record the payload,
   // according to the type of the log entry.
   oneof payload {
-    // Used by CLIENT_INIT_METADATA, SERVER_INIT_METADATA and TRAILING_METADATA
+    // Used by CLIENT_INIT_METADATA, SERVER_INIT_METADATA and
+    // TRAILING_METADATA. The contents may be different depending on
+    // the gRPC implementation. For example, C shows the http/2
+    // headers such as :method to applications but Java hides http/2
+    // implementation details.  Information that is guaranteed to be
+    // present for all gRPC implemetnations (such as the full method
+    // name) is always denormalized into GrpcLogEntry.
     Metadata metadata = 4;
     // Used by REQUEST and RESPONSE
     Message message = 5;
@@ -64,6 +70,9 @@ message GrpcLogEntry {
 
   // true if payload does not represent the full message or metadata.
   bool truncated = 7;
+
+  // The method name.
+  string full_method_name = 8;
 };
 
 // Message payload, used by REQUEST and RESPONSE

--- a/grpc/binlog/v1alpha/binarylog.proto
+++ b/grpc/binlog/v1alpha/binarylog.proto
@@ -53,12 +53,10 @@ message GrpcLogEntry {
   // according to the type of the log entry.
   oneof payload {
     // Used by CLIENT_INIT_METADATA, SERVER_INIT_METADATA and
-    // TRAILING_METADATA. The contents may be different depending on
-    // the gRPC implementation. For example, C shows the http/2
-    // headers such as :method to applications but Java hides http/2
-    // implementation details.  Information that is guaranteed to be
-    // present for all gRPC implemetnations (such as the full method
-    // name) is always denormalized into GrpcLogEntry.
+    // TRAILING_METADATA. The contents may be slightly different
+    // depending on the transport implementation. For example, some
+    // http2 based implementations may include extra information here
+    // like :path.
     Metadata metadata = 4;
     // Used by REQUEST and RESPONSE
     Message message = 5;

--- a/grpc/binlog/v1alpha/binarylog.proto
+++ b/grpc/binlog/v1alpha/binarylog.proto
@@ -78,8 +78,8 @@ message GrpcLogEntry {
   // encoding.
   string status_message = 10;
 
-  // the deadline in nanoseconds
-  uint64 deadline_ns = 11;
+  // the timeout in nanoseconds
+  uint64 timeout_ns = 11;
 
   // more things may go here like: authority, agent
 };

--- a/grpc/binlog/v1alpha/binarylog.proto
+++ b/grpc/binlog/v1alpha/binarylog.proto
@@ -18,6 +18,8 @@ syntax = "proto3";
 
 package grpc.binarylog.v1alpha;
 
+import "google/protobuf/duration.proto";
+
 option java_multiple_files = true;
 option java_package = "io.grpc.binarylog";
 option java_outer_classname = "BinaryLogProto";
@@ -67,7 +69,9 @@ message GrpcLogEntry {
   // true if payload does not represent the full message or metadata.
   bool truncated = 7;
 
-  // The method name. Always logged for every entry.
+  // The method name. Logged for the first entry:
+  // RECV_INITIAL_METADATA for server side or
+  // SEND_INITIAL_METADATA for client side.
   string method_name = 8;
 
   // status_code and status_message:
@@ -79,9 +83,11 @@ message GrpcLogEntry {
   string status_message = 10;
 
   // the timeout in nanoseconds
-  uint64 timeout_ns = 11;
+  google.protobuf.Duration timeout_ns = 11;
 
-  // more things may go here like: authority, agent
+  // The entry sequence id for this call. The first GrpcLogEntry has
+  // a value of 1, to disambiguate from an unset value.
+  uint32 sequence_id_within_call = 12;
 };
 
 // Message payload, used by REQUEST and RESPONSE
@@ -102,7 +108,17 @@ message Message {
 // A list of metadata pairs, used in the payload of CLIENT_INIT_METADATA,
 // SERVER_INIT_METADATA and TRAILING_METADATA
 // Implementations may omit some entries to honor the header limits
-// of GRPC_BINARY_LOG_CONFIG. Implementations can choose which entries are logged.
+// of GRPC_BINARY_LOG_CONFIG.
+// 
+// Implementations will log 'grpc-status-details-bin' unless truncated.
+//
+// Implementations will not log the following entries, and excluding them
+// will not count as a truncation:
+// - entries handled by grpc and are not user visible, such as those
+//   that begin with 'grpc-' or keys like 'lb-token'
+// - transport specific entries, including but not limited to:
+//   ':path', ':authority', 'content-encoding', 'user-agent', 'te', etc
+// - entries added for call credentials
 message Metadata {
   repeated MetadataEntry entry = 1;
 }

--- a/grpc/binlog/v1alpha/binarylog.proto
+++ b/grpc/binlog/v1alpha/binarylog.proto
@@ -18,6 +18,7 @@ syntax = "proto3";
 
 package grpc.binarylog.v1alpha;
 
+import "google/protobuf/any.proto";
 import "google/protobuf/duration.proto";
 
 option java_multiple_files = true;
@@ -78,18 +79,23 @@ message GrpcLogEntry {
   // Only present for SEND_TRAILING_METADATA on server side or
   // RECV_TRAILING_METADATA on client side.
   uint32 status_code = 9;
+
+  // The value of the 'grpc-status-details-bin' metadata key. If
+  // present, this is always an encoded 'google.rpc.Status' message.
+   google.protobuf.Any status_details = 10;
+
   // An original status message before any transport specific
   // encoding.
-  string status_message = 10;
+  string status_message = 11;
 
   // the RPC timeout
-  google.protobuf.Duration timeout = 11;
+  google.protobuf.Duration timeout = 12;
 
   // The entry sequence id for this call. The first GrpcLogEntry has a
   // value of 1, to disambiguate from an unset value. The purpose of
   // this field is to detect missing entries in environments where
   // durability or ordering is not guaranteed.
-  uint32 sequence_id_within_call = 12;
+  uint32 sequence_id_within_call = 13;
 };
 
 // Message payload, used by REQUEST and RESPONSE
@@ -112,8 +118,6 @@ message Message {
 // Implementations may omit some entries to honor the header limits
 // of GRPC_BINARY_LOG_CONFIG.
 // 
-// Implementations will log 'grpc-status-details-bin' unless truncated.
-//
 // Implementations will not log the following entries, and this is
 // not to be treated as a truncation:
 // - entries handled by grpc that are not user visible, such as those

--- a/grpc/binlog/v1alpha/binarylog.proto
+++ b/grpc/binlog/v1alpha/binarylog.proto
@@ -112,8 +112,8 @@ message Message {
 // 
 // Implementations will log 'grpc-status-details-bin' unless truncated.
 //
-// Implementations will not log the following entries, and excluding them
-// will not count as a truncation:
+// Implementations will not log the following entries, and this is
+// not to be treated as a truncation:
 // - entries handled by grpc and are not user visible, such as those
 //   that begin with 'grpc-' or keys like 'lb-token'
 // - transport specific entries, including but not limited to:

--- a/grpc/binlog/v1alpha/binarylog.proto
+++ b/grpc/binlog/v1alpha/binarylog.proto
@@ -52,13 +52,11 @@ message GrpcLogEntry {
   // The logger uses one of the following fields to record the payload,
   // according to the type of the log entry.
   oneof payload {
-    // Used by CLIENT_INIT_METADATA, SERVER_INIT_METADATA and
-    // TRAILING_METADATA. The contents may be slightly different
-    // depending on the transport implementation. For example, some
-    // http2 based implementations may include extra information here
-    // like :path.
+    // Used by {SEND,RECV}_INITIAL_METADATA and
+    // {SEND,RECV}_TRAILING_METADATA. This contains only the metadata
+    // from the application.
     Metadata metadata = 4;
-    // Used by REQUEST and RESPONSE
+    // Used by {SEND,RECV}_MESSAGE
     Message message = 5;
   }
 
@@ -69,8 +67,8 @@ message GrpcLogEntry {
   // true if payload does not represent the full message or metadata.
   bool truncated = 7;
 
-  // The method name.
-  string full_method_name = 8;
+  // The method name. Always logged for every entry.
+  string method_name = 8;
 
   // status_code and status_message:
   // Only present for SEND_TRAILING_METADATA on server side or

--- a/grpc/binlog/v1alpha/binarylog.proto
+++ b/grpc/binlog/v1alpha/binarylog.proto
@@ -18,7 +18,6 @@ syntax = "proto3";
 
 package grpc.binarylog.v1alpha;
 
-import "google/protobuf/any.proto";
 import "google/protobuf/duration.proto";
 
 option java_multiple_files = true;
@@ -82,7 +81,7 @@ message GrpcLogEntry {
 
   // The value of the 'grpc-status-details-bin' metadata key. If
   // present, this is always an encoded 'google.rpc.Status' message.
-   google.protobuf.Any status_details = 10;
+  bytes status_details = 10;
 
   // An original status message before any transport specific
   // encoding.

--- a/grpc/binlog/v1alpha/binarylog.proto
+++ b/grpc/binlog/v1alpha/binarylog.proto
@@ -82,7 +82,7 @@ message GrpcLogEntry {
   // encoding.
   string status_message = 10;
 
-  // the timeout in nanoseconds
+  // the RPC timeout
   google.protobuf.Duration timeout = 11;
 
   // The entry sequence id for this call. The first GrpcLogEntry has a

--- a/grpc/binlog/v1alpha/binarylog.proto
+++ b/grpc/binlog/v1alpha/binarylog.proto
@@ -83,10 +83,12 @@ message GrpcLogEntry {
   string status_message = 10;
 
   // the timeout in nanoseconds
-  google.protobuf.Duration timeout_ns = 11;
+  google.protobuf.Duration timeout = 11;
 
-  // The entry sequence id for this call. The first GrpcLogEntry has
-  // a value of 1, to disambiguate from an unset value.
+  // The entry sequence id for this call. The first GrpcLogEntry has a
+  // value of 1, to disambiguate from an unset value. The purpose of
+  // this field is to detect missing entries in environments where
+  // durability or ordering is not guaranteed.
   uint32 sequence_id_within_call = 12;
 };
 
@@ -114,7 +116,7 @@ message Message {
 //
 // Implementations will not log the following entries, and this is
 // not to be treated as a truncation:
-// - entries handled by grpc and are not user visible, such as those
+// - entries handled by grpc that are not user visible, such as those
 //   that begin with 'grpc-' or keys like 'lb-token'
 // - transport specific entries, including but not limited to:
 //   ':path', ':authority', 'content-encoding', 'user-agent', 'te', etc

--- a/grpc/binlog/v1alpha/binarylog.proto
+++ b/grpc/binlog/v1alpha/binarylog.proto
@@ -77,6 +77,11 @@ message GrpcLogEntry {
   // An original status message before any transport specific
   // encoding.
   string status_message = 10;
+
+  // the deadline in nanoseconds
+  uint64 deadline_ns = 11;
+
+  // more things may go here like: authority, agent
 };
 
 // Message payload, used by REQUEST and RESPONSE

--- a/grpc/binlog/v1alpha/binarylog.proto
+++ b/grpc/binlog/v1alpha/binarylog.proto
@@ -79,13 +79,13 @@ message GrpcLogEntry {
   // RECV_TRAILING_METADATA on client side.
   uint32 status_code = 9;
 
-  // The value of the 'grpc-status-details-bin' metadata key. If
-  // present, this is always an encoded 'google.rpc.Status' message.
-  bytes status_details = 10;
-
   // An original status message before any transport specific
   // encoding.
-  string status_message = 11;
+  string status_message = 10;
+
+  // The value of the 'grpc-status-details-bin' metadata key. If
+  // present, this is always an encoded 'google.rpc.Status' message.
+  bytes status_details = 11;
 
   // the RPC timeout
   google.protobuf.Duration timeout = 12;

--- a/grpc/binlog/v1alpha/binarylog.proto
+++ b/grpc/binlog/v1alpha/binarylog.proto
@@ -71,6 +71,14 @@ message GrpcLogEntry {
 
   // The method name.
   string full_method_name = 8;
+
+  // status_code and status_message:
+  // Only present for SEND_TRAILING_METADATA on server side or
+  // RECV_TRAILING_METADATA on client side.
+  uint32 status_code = 9;
+  // An original status message before any transport specific
+  // encoding.
+  string status_message = 10;
 };
 
 // Message payload, used by REQUEST and RESPONSE


### PR DESCRIPTION
Different languages may show different information to applications via
the metadata. Document this behavior and ensure that universally
required info is denormalized into the proto.