### PR TITLE
binlog: always log peer info

### DIFF
--- a/grpc/binlog/v1alpha/binarylog.proto
+++ b/grpc/binlog/v1alpha/binarylog.proto
@@ -58,8 +58,7 @@ message GrpcLogEntry {
     Message message = 5;
   }
 
-  // Peer address information, will only be recorded in SEND_INITIAL_METADATA
-  // and RECV_INITIAL_METADATA entries.
+  // Peer address information. Always logged for each entry.
   Peer peer = 6;
 };
 


### PR DESCRIPTION
We can not always rely on seeing the initial metadata proto before any messages: https://paste.googleplex.com/5223926032498688
