### PR TITLE
binarylogs: split peer address and port into separate fields

### DIFF
--- a/grpc/binlog/v1alpha/binarylog.proto
+++ b/grpc/binlog/v1alpha/binarylog.proto
@@ -105,8 +105,12 @@ message Peer {
     PEER_UNIX = 3;
   };
   PeerType peer_type = 1;
-  string peer = 2;  // value depends on peer_type
-  uint16 port = 3; // only for PEER_IPV4 and PEER_IPV6
+  // value depends on peer_type
+  string peer = 2;
+  // only for PEER_IPV4 and PEER_IPV6
+  uint16 ip_port = 3;
+  // only for PEER_IPV6
+  string ipv6_scope = 4;
 }
 
 // Used to record call_id.

--- a/grpc/binlog/v1alpha/binarylog.proto
+++ b/grpc/binlog/v1alpha/binarylog.proto
@@ -97,12 +97,15 @@ message MetadataEntry {
 message Peer {
   enum PeerType {
     UNKNOWN_PEERTYPE = 0;
-    PEER_IPV4 = 1;  // peer is 4 byte ipv4 address
-    PEER_IPV6 = 2;  // peer is 16 byte ipv6 address
-    PEER_UNIX = 3;  // peer is UDS string
+    // peer is the address in 1.2.3.4 form
+    PEER_IPV4 = 1;
+    // peer the address in canonical form (RFC5952 section 4)
+    PEER_IPV6 = 2;
+    // peer is UDS string
+    PEER_UNIX = 3;
   };
   PeerType peer_type = 1;
-  bytes peer = 2;  // value depends on peer_type
+  string peer = 2;  // value depends on peer_type
   uint16 port = 3; // only for PEER_IPV4 and PEER_IPV6
 }
 

--- a/grpc/binlog/v1alpha/binarylog.proto
+++ b/grpc/binlog/v1alpha/binarylog.proto
@@ -109,7 +109,7 @@ message Peer {
   string peer = 2;
   // only for PEER_IPV4 and PEER_IPV6
   uint16 ip_port = 3;
-  // only for PEER_IPV6
+  // Optional: only for PEER_IPV6 link local addresses
   string ipv6_scope = 4;
 }
 

--- a/grpc/binlog/v1alpha/binarylog.proto
+++ b/grpc/binlog/v1alpha/binarylog.proto
@@ -97,19 +97,19 @@ message MetadataEntry {
 message Peer {
   enum PeerType {
     UNKNOWN_PEERTYPE = 0;
-    // peer is the address in 1.2.3.4 form
+    // address is the address in 1.2.3.4 form
     PEER_IPV4 = 1;
-    // peer the address in canonical form (RFC5952 section 4)
+    // address the address in canonical form (RFC5952 section 4)
     // The scope is NOT included in the peer string.
     PEER_IPV6 = 2;
-    // peer is UDS string
+    // address is UDS string
     PEER_UNIX = 3;
   };
   PeerType peer_type = 1;
-  // value depends on peer_type
-  string peer = 2;
+  bytes peer = 2; // will be removed: do not use
+  string address = 3;
   // only for PEER_IPV4 and PEER_IPV6
-  uint16 ip_port = 3;
+  uint32 ip_port = 4;
 }
 
 // Used to record call_id.

--- a/grpc/binlog/v1alpha/binarylog.proto
+++ b/grpc/binlog/v1alpha/binarylog.proto
@@ -97,12 +97,13 @@ message MetadataEntry {
 message Peer {
   enum PeerType {
     UNKNOWN_PEERTYPE = 0;
-    PEER_IPV4 = 1;  // peer is struct sockaddr_in
-    PEER_IPV6 = 2;  // peer is struct sockaddr_in6
-    PEER_UNIX = 3;  // peer is struct sockaddr_un
+    PEER_IPV4 = 1;  // peer is 4 byte ipv4 address
+    PEER_IPV6 = 2;  // peer is 16 byte ipv6 address
+    PEER_UNIX = 3;  // peer is UDS string
   };
   PeerType peer_type = 1;
   bytes peer = 2;  // value depends on peer_type
+  uint16 port = 3; // only for PEER_IPV4 and PEER_IPV6
 }
 
 // Used to record call_id.

--- a/grpc/binlog/v1alpha/binarylog.proto
+++ b/grpc/binlog/v1alpha/binarylog.proto
@@ -100,6 +100,7 @@ message Peer {
     // peer is the address in 1.2.3.4 form
     PEER_IPV4 = 1;
     // peer the address in canonical form (RFC5952 section 4)
+    // The scope is NOT included in the peer string.
     PEER_IPV6 = 2;
     // peer is UDS string
     PEER_UNIX = 3;
@@ -109,8 +110,6 @@ message Peer {
   string peer = 2;
   // only for PEER_IPV4 and PEER_IPV6
   uint16 ip_port = 3;
-  // Optional: only for PEER_IPV6 link local addresses
-  string ipv6_scope = 4;
 }
 
 // Used to record call_id.


### PR DESCRIPTION
Using sockaddr_in is leaking C implementation details into the proto.
Since we really only care about address and port, let's just store
exactly that. This makes it much easier for tooling and non-C gRPC
implementations to deal with Peer.