### PR TITLE
binlog: event type should be SERVER/CLIENT agnostic

### DIFF
--- a/grpc/binlog/v1alpha/binarylog.proto
+++ b/grpc/binlog/v1alpha/binarylog.proto
@@ -39,25 +39,25 @@ message GrpcLogEntry {
 
   // Enumerates the type of event
   enum EventType {
-    UNKNOWN_EVENT_TYPE = 0;
+    EVENT_TYPE_UNKNOWN = 0;
     // Headers sent from client to server
-    CLIENT_HEADER = 1;
+    EVENT_TYPE_CLIENT_HEADER = 1;
     // Headers sent from server to client
-    SERVER_HEADER = 2;
+    EVENT_TYPE_SERVER_HEADER = 2;
     // Message sent from client to server
-    CLIENT_MESSAGE = 3;
+    EVENT_TYPE_CLIENT_MESSAGE = 3;
     // message sent from server to client
-    SERVER_MESSAGE = 4;
+    EVENT_TYPE_SERVER_MESSAGE = 4;
     // Signal that client is done sending
-    CLIENT_HALF_CLOSE = 5;
+    EVENT_TYPE_CLIENT_HALF_CLOSE = 5;
     // Trailers sent from server to client.
     // On client side, this is the last network event.
-    // On server side, a CANCEL can still happen after this.
-    SERVER_TRAILER = 6;
+    // On server side, a EVENT_TYPE_CANCEL can still happen after this.
+    EVENT_TYPE_SERVER_TRAILER = 6;
     // Signal that the RPC should be cancelled
-    CANCEL = 7;
+    EVENT_TYPE_CANCEL = 7;
     // A special marker to indicate that the RPC is done.
-    END_MARKER = 8;
+    EVENT_TYPE_END_MARKER = 8;
   }
 
   // Enumerates the entity that generates the log entry
@@ -77,25 +77,26 @@ message GrpcLogEntry {
   // The logger uses one of the following fields to record the payload,
   // according to the type of the log entry.
   oneof payload {
-    // Used by REQUEST_HEADERS, RESPONSE_HEADERS and
-    // STATUS_TRAILERS. This contains only the metadata
+    // Used by EVENT_TYPE_CLIENT_HEADER, EVENT_TYPE_SERVER_HEADER and
+    // EVENT_TYPE_SERVER_TRAILER. This contains only the metadata
     // from the application.
     Metadata metadata = 4;
-    // Used by REQUEST_MESSAGE, RESPONSE_MESSAGE
+    // Used by EVENT_TYPE_CLIENT_MESSAGE, EVENT_TYPE_SERVER_MESSAGE
     Message message = 5;
   }
 
-  // Peer address information, will only be recorded in REQUEST_HEADERS
+  // Peer address information, will only be recorded in
+  // EVENT_TYPE_CLIENT_HEADER or EVENT_TYPE_SERVER_HEADER
   Peer peer = 6;
 
   // true if payload does not represent the full message or metadata.
   bool truncated = 7;
 
-  // The method name. Logged for REQUEST_HEADERS
+  // The method name. Logged for EVENT_TYPE_CLIENT_HEADER
   string method_name = 8;
 
   // status_code and status_message:
-  // Only present for STATUS_TRAILERS.
+  // Only present for EVENT_TYPE_SERVER_TRAILER.
   uint32 status_code = 9;
 
   // An original status message before any transport specific
@@ -119,7 +120,7 @@ message GrpcLogEntry {
   EventType event_type = 14;
 };
 
-// Message payload, used by REQUEST_MESSAGE and RESPONSE_MESSAGE
+// Message payload, used by CLIENT_MESSAGE and SERVER_MESSAGE
 message Message {
   // This flag is currently used to indicate whether the payload is compressed,
   // it may contain other semantics in the future. Value of 1 indicates that the
@@ -134,8 +135,8 @@ message Message {
   bytes data = 3;
 }
 
-// A list of metadata pairs, used in the payload of REQUEST_HEADERS,
-// RESPONSE_HEADERS and STATUS_TRAILERS.
+// A list of metadata pairs, used in the payload of CLIENT_HEADER,
+// SERVER_HEADER and SERVER_TRAILER.
 // Implementations may omit some entries to honor the header limits
 // of GRPC_BINARY_LOG_CONFIG.
 // 

--- a/grpc/binlog/v1alpha/binarylog.proto
+++ b/grpc/binlog/v1alpha/binarylog.proto
@@ -37,28 +37,27 @@ message GrpcLogEntry {
     RECV_MESSAGE = 6;
   }
 
-  // Enumerates the type of logs
+  // Enumerates the type of event
   enum EventType {
     UNKNOWN_EVENT_TYPE = 0;
     // Headers sent from client to server
-    REQUEST_HEADERS = 1;
+    CLIENT_HEADER = 1;
     // Headers sent from server to client
-    RESPONSE_HEADERS = 2;
+    SERVER_HEADER = 2;
     // Message sent from client to server
-    REQUEST_MESSAGE = 3;
+    CLIENT_MESSAGE = 3;
     // message sent from server to client
-    RESPONSE_MESSAGE = 4;
+    SERVER_MESSAGE = 4;
     // Signal that client is done sending
-    HALF_CLOSE = 5;
+    CLIENT_HALF_CLOSE = 5;
     // Trailers sent from server to client.
-    // On client side, this is the final entry for an RPC.
+    // On client side, this is the last network event.
     // On server side, a CANCEL can still happen after this.
-    STATUS_TRAILERS = 6;
+    SERVER_TRAILER = 6;
     // Signal that the RPC should be cancelled
     CANCEL = 7;
-    // A special event that only applicable to server side.
-    // This is the final entry for an RPC.
-    SERVER_END_MARKER = 8;
+    // A special marker to indicate that the RPC is done.
+    END_MARKER = 8;
   }
 
   // Enumerates the entity that generates the log entry

--- a/grpc/binlog/v1alpha/binarylog.proto
+++ b/grpc/binlog/v1alpha/binarylog.proto
@@ -39,7 +39,7 @@ message GrpcLogEntry {
 
   // Enumerates the type of logs
   enum EventType {
-    UNKNOWN_TYPE = 0;
+    UNKNOWN_EVENT_TYPE = 0;
     // Headers sent from client to server
     REQUEST_HEADERS = 1;
     // Headers sent from server to client

--- a/grpc/binlog/v1alpha/binarylog.proto
+++ b/grpc/binlog/v1alpha/binarylog.proto
@@ -40,18 +40,25 @@ message GrpcLogEntry {
   // Enumerates the type of logs
   enum EventType {
     UNKNOWN_TYPE = 0;
-    // headers sent from client to server
+    // Headers sent from client to server
     REQUEST_HEADERS = 1;
-    // headers sent from server to client
+    // Headers sent from server to client
     RESPONSE_HEADERS = 2;
-    // message sent from client to server
+    // Message sent from client to server
     REQUEST_MESSAGE = 3;
     // message sent from server to client
     RESPONSE_MESSAGE = 4;
-    // signal that client is done sending
+    // Signal that client is done sending
     HALF_CLOSE = 5;
-    // trailers sent from server to client
+    // Trailers sent from server to client.
+    // On client side, this is the final entry for an RPC.
+    // On server side, a CANCEL can still happen after this.
     STATUS_TRAILERS = 6;
+    // Signal that the RPC should be cancelled
+    CANCEL = 7;
+    // A special event that only applicable to server side.
+    // This is the final entry for an RPC.
+    SERVER_END_MARKER = 8;
   }
 
   // Enumerates the entity that generates the log entry

--- a/grpc/binlog/v1alpha/binarylog.proto
+++ b/grpc/binlog/v1alpha/binarylog.proto
@@ -26,7 +26,7 @@ option java_outer_classname = "BinaryLogProto";
 
 // Log entry we store in binary logs
 message GrpcLogEntry {
-  // Enumerates the type of logs
+  // Enumerates the type of logs (deprecated)
   enum Type {
     UNKNOWN_TYPE = 0;
     SEND_INITIAL_METADATA = 1;
@@ -35,7 +35,18 @@ message GrpcLogEntry {
     RECV_INITIAL_METADATA = 4;
     RECV_TRAILING_METADATA = 5;
     RECV_MESSAGE = 6;
-  };
+  }
+
+  // Enumerates the type of logs
+  enum EventType {
+    UNKNOWN_TYPE = 0;
+    REQUEST_HEADERS = 1;
+    RESPONSE_HEADERS = 2;
+    REQUEST_MESSAGE = 3;
+    RESPONSE_MESSAGE = 4;
+    HALF_CLOSE = 5;
+    STATUS_TRAILERS = 6;
+  }
 
   // Enumerates the entity that generates the log entry
   enum Logger {
@@ -44,7 +55,7 @@ message GrpcLogEntry {
     SERVER = 2;
   }
 
-  Type type = 1;      // One of the above Type enum
+  Type type = 1 [deprecated = true];  // Deprecated do not use
   Logger logger = 2;  // One of the above Logger enum
 
   // Uniquely identifies a call. Each call may have several log entries, they
@@ -54,29 +65,25 @@ message GrpcLogEntry {
   // The logger uses one of the following fields to record the payload,
   // according to the type of the log entry.
   oneof payload {
-    // Used by {SEND,RECV}_INITIAL_METADATA and
-    // {SEND,RECV}_TRAILING_METADATA. This contains only the metadata
+    // Used by REQUEST_HEADERS, RESPONSE_HEADERS and
+    // STATUS_TRAILERS. This contains only the metadata
     // from the application.
     Metadata metadata = 4;
-    // Used by {SEND,RECV}_MESSAGE
+    // Used by REQUEST_MESSAGE, RESPONSE_MESSAGE
     Message message = 5;
   }
 
-  // Peer address information, will only be recorded in SEND_INITIAL_METADATA
-  // and RECV_INITIAL_METADATA entries.
+  // Peer address information, will only be recorded in REQUEST_HEADERS
   Peer peer = 6;
 
   // true if payload does not represent the full message or metadata.
   bool truncated = 7;
 
-  // The method name. Logged for the first entry:
-  // RECV_INITIAL_METADATA for server side or
-  // SEND_INITIAL_METADATA for client side.
+  // The method name. Logged for REQUEST_HEADERS
   string method_name = 8;
 
   // status_code and status_message:
-  // Only present for SEND_TRAILING_METADATA on server side or
-  // RECV_TRAILING_METADATA on client side.
+  // Only present for STATUS_TRAILERS.
   uint32 status_code = 9;
 
   // An original status message before any transport specific
@@ -95,9 +102,12 @@ message GrpcLogEntry {
   // this field is to detect missing entries in environments where
   // durability or ordering is not guaranteed.
   uint32 sequence_id_within_call = 13;
+
+  // Enumerates the type of logs
+  EventType event_type = 14;
 };
 
-// Message payload, used by REQUEST and RESPONSE
+// Message payload, used by REQUEST_MESSAGE and RESPONSE_MESSAGE
 message Message {
   // This flag is currently used to indicate whether the payload is compressed,
   // it may contain other semantics in the future. Value of 1 indicates that the
@@ -112,8 +122,8 @@ message Message {
   bytes data = 3;
 }
 
-// A list of metadata pairs, used in the payload of CLIENT_INIT_METADATA,
-// SERVER_INIT_METADATA and TRAILING_METADATA
+// A list of metadata pairs, used in the payload of REQUEST_HEADERS,
+// RESPONSE_HEADERS and STATUS_TRAILERS.
 // Implementations may omit some entries to honor the header limits
 // of GRPC_BINARY_LOG_CONFIG.
 // 

--- a/grpc/binlog/v1alpha/binarylog.proto
+++ b/grpc/binlog/v1alpha/binarylog.proto
@@ -40,11 +40,17 @@ message GrpcLogEntry {
   // Enumerates the type of logs
   enum EventType {
     UNKNOWN_TYPE = 0;
+    // headers sent from client to server
     REQUEST_HEADERS = 1;
+    // headers sent from server to client
     RESPONSE_HEADERS = 2;
+    // message sent from client to server
     REQUEST_MESSAGE = 3;
+    // message sent from server to client
     RESPONSE_MESSAGE = 4;
+    // signal that client is done sending
     HALF_CLOSE = 5;
+    // trailers sent from server to client
     STATUS_TRAILERS = 6;
   }
 


### PR DESCRIPTION
This way of expressing events makes the proto much easier to consume. This should be an easy change for existing binlog implementations.

A few concrete examples of pain points:
- when replaying traffic against a real server, we must check whether the logs are recorded on client side or server side, and as a result play back sent messages vs received messages.
- for printing the message payloads, the protobuf API is expressed in terms of method input types and output types : https://developers.google.com/protocol-buffers/docs/reference/cpp/google.protobuf.descriptor#MethodDescriptor . So we must go through the extra step of checking client vs server before we can print a message.

