### PR TITLE
Fix binarylog's java_package to include version

### DIFF
--- a/grpc/binlog/v1alpha/binarylog.proto
+++ b/grpc/binlog/v1alpha/binarylog.proto
@@ -21,7 +21,7 @@ package grpc.binarylog.v1alpha;
 import "google/protobuf/duration.proto";
 
 option java_multiple_files = true;
-option java_package = "io.grpc.binarylog";
+option java_package = "io.grpc.binarylog.v1alpha";
 option java_outer_classname = "BinaryLogProto";
 
 // Log entry we store in binary logs


### PR DESCRIPTION
Since this is a breaking change, it will need to be coordinated with the Java sync.

grpc/grpc-java#4704