### PR TITLE
Fix grpclb's java_package to match the proto and include version

### DIFF
--- a/grpc/lb/v1/load_balancer.proto
+++ b/grpc/lb/v1/load_balancer.proto
@@ -26,7 +26,7 @@ import "google/protobuf/timestamp.proto";
 option go_package = "google.golang.org/grpc/balancer/grpclb/grpc_lb_v1";
 option java_multiple_files = true;
 option java_outer_classname = "LoadBalancerProto";
-option java_package = "io.grpc.grpclb";
+option java_package = "io.grpc.lb.v1";
 
 service LoadBalancer {
   // Bidirectional rpc to get a list of servers.


### PR DESCRIPTION
There are no Java users of this proto internally, so this won't cause problems during the sync.

grpc/grpc-java#4705