### PR TITLE
Fix import path

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -43,6 +43,12 @@ proto_library(
 )
 
 proto_library(
+    name = "report_qps_scenario_service_proto",
+    srcs = ["grpc/testing/report_qps_scenario_service.proto"],
+    deps = [":control_proto"],
+)
+
+proto_library(
     name = "worker_service_proto",
     srcs = [
         "grpc/testing/worker_service.proto",

--- a/grpc/testing/report_qps_scenario_service.proto
+++ b/grpc/testing/report_qps_scenario_service.proto
@@ -16,7 +16,7 @@
 // of unary/streaming requests/responses.
 syntax = "proto3";
 
-import "src/proto/grpc/testing/control.proto";
+import "grpc/testing/control.proto";
 
 package grpc.testing;
 


### PR DESCRIPTION
The import path should reflect what is in this repo. During import to
internal, there are rules that expect this convention.