### PR TITLE
Add result cardinality limit to requests.

### DIFF
--- a/grpc/channelz/v1/channelz.proto
+++ b/grpc/channelz/v1/channelz.proto
@@ -177,6 +177,7 @@ message SubchannelRef {
 
 // SocketRef is a reference to a Socket.
 message SocketRef {
+  // The globally unique id for this socket.  Must be a positive number.
   int64 socket_id = 3;
   // An optional name associated with the socket.
   string name = 4;

--- a/grpc/channelz/v1/channelz.proto
+++ b/grpc/channelz/v1/channelz.proto
@@ -435,9 +435,14 @@ service Channelz {
 }
 
 message GetTopChannelsRequest {
-  // start_channel_id indicates that only channels at or above this id should be
+  // start_channel_id indicates that only channels above this id should be
   // included in the results.
   int64 start_channel_id = 1;
+
+  // If non-zero, the server will return a page of results whose
+  // cardinality is equal to or less than this value. If zero, the
+  // server will choose a reasonable page size.
+  uint32 limit = 2;
 }
 
 message GetTopChannelsResponse {
@@ -451,9 +456,14 @@ message GetTopChannelsResponse {
 }
 
 message GetServersRequest {
-  // start_server_id indicates that only servers at or above this id should be
+  // start_server_id indicates that only servers above this id should be
   // included in the results.
   int64 start_server_id = 1;
+
+  // If non-zero, the server will return a page of results whose
+  // cardinality is equal to or less than this value. If zero, the
+  // server will choose a reasonable page size.
+  uint32 limit = 2;
 }
 
 message GetServersResponse {
@@ -468,9 +478,14 @@ message GetServersResponse {
 
 message GetServerSocketsRequest {
   int64 server_id = 1;
-  // start_socket_id indicates that only sockets at or above this id should be
+  // start_socket_id indicates that only sockets above this id should be
   // included in the results.
   int64 start_socket_id = 2;
+
+  // If non-zero, the server will return a page of results whose
+  // cardinality is equal to or less than this value. If zero, the
+  // server will choose a reasonable page size.
+  uint32 limit = 3;
 }
 
 message GetServerSocketsResponse {

--- a/grpc/channelz/v1/channelz.proto
+++ b/grpc/channelz/v1/channelz.proto
@@ -436,19 +436,23 @@ service Channelz {
 }
 
 message GetTopChannelsRequest {
-  // start_channel_id indicates that only channels above this id should be
+  // start_channel_id indicates that only channels at or above this id should be
   // included in the results.
+  // To request the first page, this must be set to 0. To request
+  // subsequent pages, the client generates this value by adding 1 to
+  // the highest seen result ID.
   int64 start_channel_id = 1;
 
-  // If non-zero, the server will return a page of results whose
-  // cardinality is equal to or less than this value. If zero, the
-  // server will choose a reasonable page size.
-  uint32 limit = 2;
+  // If non-zero, the server will return a page of results containing
+  // at most this many items. If zero, the server will choose a
+  // reasonable page size.  Must never be negative.
+  int32 max_results = 2;
 }
 
 message GetTopChannelsResponse {
   // list of channels that the connection detail service knows about.  Sorted in
   // ascending channel_id order.
+  // Must contain at least 1 result, otherwise 'end' must be true.
   repeated Channel channel = 1;
   // If set, indicates that the list of channels is the final list.  Requesting
   // more channels can only return more if they are created after this RPC
@@ -457,19 +461,23 @@ message GetTopChannelsResponse {
 }
 
 message GetServersRequest {
-  // start_server_id indicates that only servers above this id should be
+  // start_server_id indicates that only servers at or above this id should be
   // included in the results.
+  // To request the first page, this must be set to 0. To request
+  // subsequent pages, the client generates this value by adding 1 to
+  // the highest seen result ID.
   int64 start_server_id = 1;
 
-  // If non-zero, the server will return a page of results whose
-  // cardinality is equal to or less than this value. If zero, the
-  // server will choose a reasonable page size.
-  uint32 limit = 2;
+  // If non-zero, the server will return a page of results containing
+  // at most this many items. If zero, the server will choose a
+  // reasonable page size.  Must never be negative.
+  int32 max_results = 2;
 }
 
 message GetServersResponse {
   // list of servers that the connection detail service knows about.  Sorted in
   // ascending server_id order.
+  // Must contain at least 1 result, otherwise 'end' must be true.
   repeated Server server = 1;
   // If set, indicates that the list of servers is the final list.  Requesting
   // more servers will only return more if they are created after this RPC
@@ -479,19 +487,23 @@ message GetServersResponse {
 
 message GetServerSocketsRequest {
   int64 server_id = 1;
-  // start_socket_id indicates that only sockets above this id should be
+  // start_socket_id indicates that only sockets at or above this id should be
   // included in the results.
+  // To request the first page, this must be set to 0. To request
+  // subsequent pages, the client generates this value by adding 1 to
+  // the highest seen result ID.
   int64 start_socket_id = 2;
 
-  // If non-zero, the server will return a page of results whose
-  // cardinality is equal to or less than this value. If zero, the
-  // server will choose a reasonable page size.
-  uint32 limit = 3;
+  // If non-zero, the server will return a page of results containing
+  // at most this many items. If zero, the server will choose a
+  // reasonable page size.  Must never be negative.
+  int32 max_results = 3;
 }
 
 message GetServerSocketsResponse {
   // list of socket refs that the connection detail service knows about.  Sorted in
   // ascending socket_id order.
+  // Must contain at least 1 result, otherwise 'end' must be true.
   repeated SocketRef socket_ref = 1;
   // If set, indicates that the list of sockets is the final list.  Requesting
   // more sockets will only return more if they are created after this RPC

--- a/grpc/channelz/v1/channelz.proto
+++ b/grpc/channelz/v1/channelz.proto
@@ -438,7 +438,7 @@ service Channelz {
 message GetTopChannelsRequest {
   // start_channel_id indicates that only channels at or above this id should be
   // included in the results.
-  // To request the first page, this must be set to 0. To request
+  // To request the first page, this should be set to 0. To request
   // subsequent pages, the client generates this value by adding 1 to
   // the highest seen result ID.
   int64 start_channel_id = 1;

--- a/grpc/channelz/v1/channelz.proto
+++ b/grpc/channelz/v1/channelz.proto
@@ -446,7 +446,7 @@ message GetTopChannelsRequest {
   // If non-zero, the server will return a page of results containing
   // at most this many items. If zero, the server will choose a
   // reasonable page size.  Must never be negative.
-  int32 max_results = 2;
+  int64 max_results = 2;
 }
 
 message GetTopChannelsResponse {
@@ -471,7 +471,7 @@ message GetServersRequest {
   // If non-zero, the server will return a page of results containing
   // at most this many items. If zero, the server will choose a
   // reasonable page size.  Must never be negative.
-  int32 max_results = 2;
+  int64 max_results = 2;
 }
 
 message GetServersResponse {
@@ -497,7 +497,7 @@ message GetServerSocketsRequest {
   // If non-zero, the server will return a page of results containing
   // at most this many items. If zero, the server will choose a
   // reasonable page size.  Must never be negative.
-  int32 max_results = 3;
+  int64 max_results = 3;
 }
 
 message GetServerSocketsResponse {


### PR DESCRIPTION
This requires tweaking how pagination works. Otherwise, it would not
be possible to paginate 1 result at a time. This implies that 0 MUST
NOT be a valid ID for any channelz entity.

See https://github.com/grpc/proposal/pull/114