### PR TITLE
Add 'summary' field to GetSocketRequest

### DIFF
--- a/grpc/channelz/v1/channelz.proto
+++ b/grpc/channelz/v1/channelz.proto
@@ -234,9 +234,8 @@ message Socket {
   Address local = 3;
   // The remote bound address.  May be absent.
   Address remote = 4;
-  // Security details for this socket.  May be absent if not available, if
-  // there is no security on the socket, or if 'summary' is set on
-  // GetSocketRequest.
+  // Security details for this socket.  May be absent if not available, or
+  // there is no security on the socket.
   Security security = 5;
 
   // Optional, represents the name of the remote endpoint, if different than

--- a/grpc/channelz/v1/channelz.proto
+++ b/grpc/channelz/v1/channelz.proto
@@ -234,8 +234,9 @@ message Socket {
   Address local = 3;
   // The remote bound address.  May be absent.
   Address remote = 4;
-  // Security details for this socket.  May be absent if not available, or
-  // there is no security on the socket.
+  // Security details for this socket.  May be absent if not available, if
+  // there is no security on the socket, or if 'summary' is set on
+  // GetSocketRequest.
   Security security = 5;
 
   // Optional, represents the name of the remote endpoint, if different than
@@ -288,7 +289,8 @@ message SocketData {
   // include stream level or TCP level flow control info.
   google.protobuf.Int64Value  remote_flow_control_window = 12;
 
-  // Socket options set on this socket.  May be absent.
+  // Socket options set on this socket.  May be absent if 'summary' is set
+  // on GetSocketRequest.
   repeated SocketOption option = 13;
 }
 
@@ -508,6 +510,11 @@ message GetSubchannelResponse {
 message GetSocketRequest {
   // socket_id is the identifier of the specific socket to get.
   int64 socket_id = 1;
+
+  // If true, the response will contain only high level information
+  // that is inexpensive to obtain. Fields thay may be omitted are
+  // documented.
+  bool summary = 2;
 }
 
 message GetSocketResponse {


### PR DESCRIPTION
If set, only return a high level summary.

I don't think the security info is relevant either for the high level view of a socket. I can revert this if we disagree.

Even though any field can be absent in proto3, it's probably still a good idea to document what 'summary' should suppress. Otherwise it's not clear if socket addresses, `last_local_stream_created_timestamp`, or `last_message_sent_timestamp` is expected to be present.