### PR TITLE
adds java_proto_library rules for all public protos.

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -70,10 +70,22 @@ proto_library(
     ],
 )
 
+java_proto_library(
+    name = "channelz_java_proto",
+    visibility = ["//visibility:public"],
+    deps = [":channelz_proto"],
+)
+
 proto_library(
     name = "health_proto",
     srcs = ["grpc/health/v1/health.proto"],
     visibility = ["//visibility:public"],
+)
+
+java_proto_library(
+    name = "health_java_proto",
+    visibility = ["//visibility:public"],
+    deps = [":health_proto"],
 )
 
 proto_library(
@@ -86,6 +98,12 @@ proto_library(
     visibility = ["//visibility:public"],
 )
 
+java_proto_library(
+    name = "alts_handshaker_java_proto",
+    visibility = ["//visibility:public"],
+    deps = [":alts_handshaker_proto"],
+)
+
 proto_library(
     name = "binarylog_proto",
     srcs = ["grpc/binlog/v1alpha/binarylog.proto"],
@@ -93,6 +111,12 @@ proto_library(
     deps = [
         "@com_google_protobuf//:duration_proto",
     ],
+)
+
+java_proto_library(
+    name = "binarylog_java_proto",
+    visibility = ["//visibility:public"],
+    deps = [":binarylog_proto"],
 )
 
 proto_library(
@@ -105,10 +129,22 @@ proto_library(
     ],
 )
 
+java_proto_library(
+    name = "grpclb_load_balancer_java_proto",
+    visibility = ["//visibility:public"],
+    deps = [":grpclb_load_balancer_proto"],
+)
+
 proto_library(
     name = "reflection_proto",
     srcs = ["grpc/reflection/v1/reflection.proto"],
     visibility = ["//visibility:public"],
+)
+
+java_proto_library(
+    name = "reflection_java_proto",
+    visibility = ["//visibility:public"],
+    deps = [":reflection_proto"],
 )
 
 # Deprecated: do not use

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -15,10 +15,11 @@
 # proto_library, cc_proto_library, and java_proto_library rules implicitly
 # depend on @com_google_protobuf for protoc and proto runtimes.
 # This statement defines the @com_google_protobuf repo.
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
 http_archive(
     name = "com_google_protobuf",
-    sha256 = "1f8b9b202e9a4e467ff0b0f25facb1642727cdf5e69092038f15b37c75b99e45",
-    strip_prefix = "protobuf-3.5.1",
-    urls = ["https://github.com/google/protobuf/archive/v3.5.1.zip"],
+    sha256 = "d6618d117698132dadf0f830b762315807dc424ba36ab9183f1f436008a2fdb6",
+    strip_prefix = "protobuf-3.6.1.2",
+    urls = ["https://github.com/google/protobuf/archive/v3.6.1.2.zip"],
 )
-


### PR DESCRIPTION
This makes it possible for grpc-java to properly depend on the java protos it needs to in its services/ source tree.

NOTE: This also upgrades protobuf to a newer version and fixes more recent Bazel deprecation errors.
Everything builds fine.