### PR TITLE
deprecated reflection proto must be exposed.

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -152,3 +152,9 @@ proto_library(
     name = "reflection_proto_deprecated",
     srcs = ["grpc/reflection/v1alpha/reflection.proto"],
 )
+
+# Deprecated: do not use
+java_proto_library(
+    name = "reflection_java_proto_deprecated",
+    deps = [":reflection_proto_deprecated"],
+)


### PR DESCRIPTION
gRPC still makes use of it currently:
https://github.com/grpc/grpc-java/pull/5384