### PR TITLE
Switch to binarylog_proto v1.

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -106,7 +106,7 @@ java_proto_library(
 
 proto_library(
     name = "binarylog_proto",
-    srcs = ["grpc/binlog/v1alpha/binarylog.proto"],
+    srcs = ["grpc/binlog/v1/binarylog.proto"],
     visibility = ["//visibility:public"],
     deps = [
         "@com_google_protobuf//:duration_proto",


### PR DESCRIPTION
grpc-java was ported to v1.

I could have sworn it was v1alpha, but I see references to v1 in my other PR:
https://github.com/grpc/grpc-java/blob/master/services/src/main/java/io/grpc/services/BinlogHelper.java

