### PR TITLE
Adding timestamp dep to binarylog_proto

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -110,6 +110,7 @@ proto_library(
     visibility = ["//visibility:public"],
     deps = [
         "@com_google_protobuf//:duration_proto",
+        "@com_google_protobuf//:timestamp_proto",
     ],
 )
 


### PR DESCRIPTION
Hello again. I believe this is the final time I will be doing this.
I've verified that I can do: `bazel build grpc-java/services/...`  successfully.

FWIW, this repository should probably have some build automation which could have saved us all a bunch of time.