### PR TITLE
Issue #53: Add a Readiness check as a mirror to Health to support differentiated…

### DIFF
--- a/grpc/health/v1/health.proto
+++ b/grpc/health/v1/health.proto
@@ -61,3 +61,26 @@ service Health {
   // clients should retry the call with appropriate exponential backoff.
   rpc Watch(HealthCheckRequest) returns (stream HealthCheckResponse);
 }
+
+service Readiness {
+  // If the requested service is unknown, the call will fail with status
+  // NOT_FOUND.
+  rpc Check(HealthCheckRequest) returns (HealthCheckResponse);
+
+  // Performs a watch for the readiness status of the requested service.
+  // The server will immediately send back a message indicating the current
+  // readiness status.  It will then subsequently send a new message
+  // whenever the service's serving status changes.
+  //
+  // If the requested service is unknown when the call is received, the
+  // server will send a message setting the serving status to
+  // SERVICE_UNKNOWN but will *not* terminate the call.  If at some
+  // future point, the serving status of the service becomes known, the
+  // server will send a new message with the service's serving status.
+  //
+  // If the call terminates with status UNIMPLEMENTED, then clients
+  // should assume this method is not supported and should not retry the
+  // call.  If the call terminates with any other status (including OK),
+  // clients should retry the call with appropriate exponential backoff.
+  rpc Watch(HealthCheckRequest) returns (stream HealthCheckResponse);
+}


### PR DESCRIPTION
… Liveness and Readiness checks for Kubernetes.