### PR TITLE
Add optional grpclb_path field to SimpleResponse

### DIFF
--- a/grpc/testing/messages.proto
+++ b/grpc/testing/messages.proto
@@ -48,6 +48,21 @@ message EchoStatus {
   string message = 2;
 }
 
+// The type of route that a client took to reach a server w.r.t. gRPCLB.
+// The server must fill in "fallback" if it detects that the RPC reached
+// the server via the "gRPCLB fallback" path, and "backend" if it detects
+// that the RPC reached the server via "gRPCLB backend" path (i.e. if it got
+// the address of this server from the gRPCLB server BalanceLoad RPC). Exactly
+// how this detection is done is context and server dependant.
+enum GrpclbRouteType {
+  // Server didn't detect the route that a client took to reach it.
+  UNKNOWN = 0;
+  // Indicates that a client reached a server via gRPCLB fallback.
+  FALLBACK = 1;
+  // Indicates that a client reached a server as a gRPCLB-given backend.
+  BACKEND = 2;
+}
+
 // Unary request.
 message SimpleRequest {
   // Desired payload type in the response from the server.
@@ -80,6 +95,9 @@ message SimpleRequest {
 
   // Whether SimpleResponse should include server_id.
   bool fill_server_id = 9;
+
+  // Whether SimpleResponse should include grpclb_route_type.
+  bool fill_grpclb_route_type = 10;
 }
 
 // Unary response, as configured by the request.
@@ -94,6 +112,8 @@ message SimpleResponse {
   // Server ID. This must be unique among different server instances,
   // but the same across all RPC's made to a particular server instance.
   string server_id = 4;
+  // gRPCLB Path.
+  GrpclbRouteType grpclb_route_type = 5;
 }
 
 // Client-streaming request.


### PR DESCRIPTION
This is in order to add a couple of new tests around grpclb fallback

Test descriptions already discussed offline