### PR TITLE
Add fallback_response type to load balance response message

### DIFF
--- a/grpc/lb/v1/load_balancer.proto
+++ b/grpc/lb/v1/load_balancer.proto
@@ -94,8 +94,14 @@ message LoadBalanceResponse {
     // Contains the list of servers selected by the load balancer. The client
     // should send requests to these servers in the specified order.
     ServerList server_list = 2;
+
+    // If this field is set, then the client should eagerly enter fallback
+    // mode (even if there are existing, healthy connections to backends).
+    FallbackResponse fallback_response = 3;
   }
 }
+
+message FallbackResponse {}
 
 message InitialLoadBalanceResponse {
   // This is an application layer redirect that indicates the client should use


### PR DESCRIPTION
To support scenarios where we want the load balancer to explicitly tell a client to eagerly enter fallback mode.