### PR TITLE
Change semantics for max_age missing or zero

### DIFF
--- a/grpc/lookup/v1/rls_config.proto
+++ b/grpc/lookup/v1/rls_config.proto
@@ -156,7 +156,7 @@ message RouteLookupConfig {
   google.protobuf.Duration lookup_service_timeout = 4;
 
   // How long are responses valid for (like HTTP Cache-Control).
-  // If omitted (i.e. 0), responses are considered not to be cacheable.
+  // If omitted or zero, the longest valid cache time is used.
   // This value is clamped to 5 minutes to avoid unflushable bad responses.
   google.protobuf.Duration max_age = 5;
 


### PR DESCRIPTION
Rather than mean "no caching", it instead means "maximum caching".
Consensus is that we don't want to allow disabling caching by setting
max_age to zero.