### PR TITLE
grpc/service_config: Add target_name field to grpclb config.

### DIFF
--- a/grpc/service_config/service_config.proto
+++ b/grpc/service_config/service_config.proto
@@ -187,8 +187,9 @@ message GrpcLbConfig {
   // Multiple LB policies can be specified; clients will iterate through
   // the list in order and stop at the first policy that they support.
   repeated LoadBalancingConfig child_policy = 1;
-  // If specified, overrides the name of the target to be sent to the balancer.
-  optional string target_name = 2;
+  // Optional.  If specified, overrides the name of the target to be sent to
+  // the balancer.
+  string target_name = 2;
 }
 
 // Configuration for the cds LB policy.

--- a/grpc/service_config/service_config.proto
+++ b/grpc/service_config/service_config.proto
@@ -187,6 +187,8 @@ message GrpcLbConfig {
   // Multiple LB policies can be specified; clients will iterate through
   // the list in order and stop at the first policy that they support.
   repeated LoadBalancingConfig child_policy = 1;
+  // If specified, overrides the name of the target to be sent to the balancer.
+  optional string target_name = 2;
 }
 
 // Configuration for the cds LB policy.

--- a/grpc/service_config/service_config.proto
+++ b/grpc/service_config/service_config.proto
@@ -187,9 +187,9 @@ message GrpcLbConfig {
   // Multiple LB policies can be specified; clients will iterate through
   // the list in order and stop at the first policy that they support.
   repeated LoadBalancingConfig child_policy = 1;
-  // Optional.  If specified, overrides the name of the target to be sent to
+  // Optional.  If specified, overrides the name of the service to be sent to
   // the balancer.
-  string target_name = 2;
+  string service_name = 2;
 }
 
 // Configuration for the cds LB policy.


### PR DESCRIPTION
This will be used by rls to override the name of the target to be sent
to the remote balancer.