### PR TITLE
service_config: update doc for MethodConfig and LoadBalancingConfig

### DIFF
--- a/grpc/service_config/service_config.proto
+++ b/grpc/service_config/service_config.proto
@@ -36,21 +36,31 @@ option java_outer_classname = "ServiceConfigProto";
 
 // Configuration for a method.
 message MethodConfig {
-  // The names of the methods to which this configuration applies. There must
-  // be at least one name. Each name entry must be unique across the entire
-  // ClientConfig. If the 'method' field is empty, then this MethodConfig
-  // specifies the defaults for all methods for the specified service.
+  // The names of the methods to which this configuration applies.
+  // - MethodConfig without names (empty list) will be skipped.
+  // - Each name entry must be unique across the entire ClientConfig.
+  // - If the 'method' field is empty, this MethodConfig specifies the defaults
+  //   for all methods for the specified service.
+  // - If the 'service' field is empty, this MethodConfig specifies the default
+  //   for all methods (it's the default config).
   //
   // For example, let's say that the service config contains the following
   // MethodConfig entries:
   //
+  // method_config { name { } ... }
   // method_config { name { service: "MyService" } ... }
   // method_config { name { service: "MyService" method: "Foo" } ... }
   //
-  // For a request for MyService/Foo, we will use the second entry, because it
-  // exactly matches the service and method name.
-  // For a request for MyService/Bar, we will use the first entry, because it
-  // provides the default for all methods of MyService.
+  // MyService/Foo will use the third entry, because it exactly matches the
+  // service and method name. MyService/Bar will use the second entry, because
+  // it provides the default for all methods of MyService. AnotherService/Baz
+  // will use the first entry, because it doesn't match the other two.
+  //
+  // In JSON representation, "" the same as null, and no present. The followings
+  // are the same:
+  // - { "service": "s" }
+  // - { "service": "s", "name": null }
+  // - { "service": "s", "name": "" }
   message Name {
     string service = 1;  // Required. Includes proto package name.
     string method = 2;
@@ -220,10 +230,15 @@ message XdsConfig {
 
 // Selects LB policy and provides corresponding configuration.
 //
-// In general, all instances of this field should be repeated.
-// Clients will iterate through the list in order and stop at the first
-// policy that they support.  This allows the service config to specify
-// custom policies that may not be known to all clients.
+// In general, all instances of this field should be repeated. Clients will
+// iterate through the list in order and stop at the first policy that they
+// support.  This allows the service config to specify custom policies that may
+// not be known to all clients.
+//
+// - If the config for the first registered policy is invalid, the whole service
+//   config is invalid.
+// - If the list doesn't contain any registered policy, the whole service config
+//   is invalid.
 message LoadBalancingConfig {
   // Exactly one LB policy may be configured.
   oneof policy {

--- a/grpc/service_config/service_config.proto
+++ b/grpc/service_config/service_config.proto
@@ -38,15 +38,16 @@ option java_outer_classname = "ServiceConfigProto";
 message MethodConfig {
   // The names of the methods to which this configuration applies.
   // - MethodConfig without names (empty list) will be skipped.
-  // - Each name entry must be unique across the entire ClientConfig.
+  // - Each name entry must be unique across the entire ServiceConfig.
   // - If the 'method' field is empty, this MethodConfig specifies the defaults
   //   for all methods for the specified service.
   // - If the 'service' field is empty, the 'method' field must be empty, and
   //   this MethodConfig specifies the default for all methods (it's the default
   //   config).
   //
-  // For example, let's say that the service config contains the following
-  // MethodConfig entries:
+  // When determining which MethodConfig to use for a given RPC, the most
+  // specific match wins. For example, let's say that the service config
+  // contains the following MethodConfig entries:
   //
   // method_config { name { } ... }
   // method_config { name { service: "MyService" } ... }
@@ -236,9 +237,9 @@ message XdsConfig {
 // support.  This allows the service config to specify custom policies that may
 // not be known to all clients.
 //
-// - If the config for the first registered policy is invalid, the whole service
+// - If the config for the first supported policy is invalid, the whole service
 //   config is invalid.
-// - If the list doesn't contain any registered policy, the whole service config
+// - If the list doesn't contain any supported policy, the whole service config
 //   is invalid.
 message LoadBalancingConfig {
   // Exactly one LB policy may be configured.

--- a/grpc/service_config/service_config.proto
+++ b/grpc/service_config/service_config.proto
@@ -41,8 +41,9 @@ message MethodConfig {
   // - Each name entry must be unique across the entire ClientConfig.
   // - If the 'method' field is empty, this MethodConfig specifies the defaults
   //   for all methods for the specified service.
-  // - If the 'service' field is empty, this MethodConfig specifies the default
-  //   for all methods (it's the default config).
+  // - If the 'service' field is empty, the 'method' field must be empty, and
+  //   this MethodConfig specifies the default for all methods (it's the default
+  //   config).
   //
   // For example, let's say that the service config contains the following
   // MethodConfig entries:
@@ -56,7 +57,7 @@ message MethodConfig {
   // it provides the default for all methods of MyService. AnotherService/Baz
   // will use the first entry, because it doesn't match the other two.
   //
-  // In JSON representation, "" the same as null, and no present. The followings
+  // In JSON representation, "" the same as null, and not present. The following
   // are the same:
   // - { "service": "s" }
   // - { "service": "s", "name": null }

--- a/grpc/service_config/service_config.proto
+++ b/grpc/service_config/service_config.proto
@@ -58,11 +58,11 @@ message MethodConfig {
   // it provides the default for all methods of MyService. AnotherService/Baz
   // will use the first entry, because it doesn't match the other two.
   //
-  // In JSON representation, "" the same as null, and not present. The following
-  // are the same:
+  // In JSON representation, value "", value `null`, and not present are the
+  // same. The following are the same Name:
   // - { "service": "s" }
-  // - { "service": "s", "name": null }
-  // - { "service": "s", "name": "" }
+  // - { "service": "s", "method": null }
+  // - { "service": "s", "method": "" }
   message Name {
     string service = 1;  // Required. Includes proto package name.
     string method = 2;


### PR DESCRIPTION
MethodConfig:
 - Allow a default config where service name is not set
 - Clarify validation

LoadBalancingConfig:
 - Clarify validation