### PR TITLE
README.md: Expand the expected usage description

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ peripheral services around gRPC such as health checking, load balancing etc..
 
 ## Usage
 
-For Bazel users, it can included directly as an http_repository.
+For Bazel users, it can be included directly as an http_repository.
 
 For others it is expected the proto files will be copied to other gRPC
 repositories as needed (e.g., `grpc/grpc`, `grpc/grpc-go`, etc.). However, those

--- a/README.md
+++ b/README.md
@@ -1,13 +1,21 @@
 # grpc-proto
-This repository contains common protocol definitions for peripheral services
-around gRPC such as health checking, load balancing etc..
+This repository contains the canonical common protocol definitions for
+peripheral services around gRPC such as health checking, load balancing etc..
 
-## Planned Usage
+## Usage
 
-For ease of development, proto files will still be copied to the other gRPC
-repositories (e.g., `grpc/grpc`, `grpc/grpc-go`, etc.). Sanity tests will be
-added to verify that common proto files match the "ground truth" files contained
-here.
+For Bazel users, it can included directly as an http_repository.
+
+For others it is expected the proto files will be copied to other gRPC
+repositories as needed (e.g., `grpc/grpc`, `grpc/grpc-go`, etc.). However, those
+copies may not be modified directly; they should be byte-identical with the
+version of grpc-proto that was copied from. All changes should be merged in
+grpc-proto before appearing in another repository. This prevents forking the
+proto and makes clear the "latest version" of the proto.
+
+Projects that copy the protos should defend against repo-specific modifications.
+They should use a script to copy that overwrites any such changes, or have
+sanity tests that would fail if a proto was no longer byte-identical.
 
 ## Directory Structure
 

--- a/README.md
+++ b/README.md
@@ -1,16 +1,15 @@
 # grpc-proto
-This repository contains the canonical common protocol definitions for
-peripheral services around gRPC such as health checking, load balancing etc..
+This repository contains the canonical versions of common protocol definitions
+for peripheral services around gRPC such as health checking and load balancing.
 
 ## Usage
 
-For Bazel users, it can be included directly as an http_repository.
+For Bazel users, it can be included directly as an `http_repository`.
 
-For others it is expected the proto files will be copied to other gRPC
-repositories as needed (e.g., `grpc/grpc`, `grpc/grpc-go`, etc.). However, those
-copies may not be modified directly; they should be byte-identical with the
-version of grpc-proto that was copied from. All changes should be merged in
-grpc-proto before appearing in another repository. This prevents forking the
+Non-Bazel users are expected to copy the proto files from this repo as needed.
+However, those copies should not be modified; they should be byte-identical with
+the version of grpc-proto that was copied from. Changes should be made to proto
+files in this repo before being recopied elsewhere. This prevents forking the
 proto and makes clear the "latest version" of the proto.
 
 Projects that copy the protos should defend against repo-specific modifications.


### PR DESCRIPTION
This also removes the expectation of the sanity tests, mainly because
they never were created and were canned before being created because
they were originally invisioned to be CI tests, which would fail PRs the
moment a comment was made to grpc-proto.

We are instead using scripts and other solutions to keep the chances of
manual changes low, while only using a single copy of the protos
in Google's internal build. Since repositories sync to Google-internal
frequently, manual changes that "get through the cracks" and break
functionality should still be discovered promptly.

Not all of that is in the README, though, because it proved hard to
integrate such that the prose was still short and to the point, while
also not being confusing to non-Google-devs. And I don't actually expect
many Google-devs would read it anyway...

CC @chalin 