### PR TITLE
Clean up unused fields in grpc/lookup/v1 protos

### DIFF
--- a/grpc/lookup/v1/rls.proto
+++ b/grpc/lookup/v1/rls.proto
@@ -36,20 +36,17 @@ message RouteLookupRequest {
 }
 
 message RouteLookupResponse {
-  // Actual addressable entity to use for routing decision, using syntax
-  // requested by the request target_type.
-  // This field is deprecated in favor of the new "targets" field, below.
-  string target = 1 [deprecated=true];
   // Prioritized list (best one first) of addressable entities to use
   // for routing, using syntax requested by the request target_type.
   // The targets will be tried in order until a healthy one is found.
-  // If present, it should be used by proxy/gRPC client code instead of
-  // "target" (which is deprecated).
   repeated string targets = 3;
   // Optional header value to pass along to AFE in the X-Google-RLS-Data header.
   // Cached with "target" and sent with all requests that match the request key.
   // Allows the RLS to pass its work product to the eventual target.
   string header_data = 2;
+
+  reserved 1;
+  reserved "target";
 }
 
 service RouteLookupService {

--- a/grpc/lookup/v1/rls_config.proto
+++ b/grpc/lookup/v1/rls_config.proto
@@ -176,40 +176,15 @@ message RouteLookupConfig {
 
   // This is a list of all the possible targets that can be returned by the
   // lookup service.  If a target not on this list is returned, it will be
-  // treated the same as an RPC error from the RLS.
+  // treated the same as an unhealthy target.
   repeated string valid_targets = 8;
 
-  // This value provides a default target to use if needed.  It will be used for
-  // request processing strategy SYNC_LOOKUP_DEFAULT_TARGET_ON_ERROR if RLS
-  // returns an error, or strategy ASYNC_LOOKUP_DEFAULT_TARGET_ON_MISS if RLS
-  // returns an error or there is a cache miss in the client.  It will also be
-  // used if there are no healthy backends for an RLS target.  Note that
-  // requests can be routed only to a subdomain of the original target,
-  // e.g. "us_east_1.cloudbigtable.googleapis.com".
+  // This value provides a default target to use if needed.  If set, it will be
+  // used if RLS returns an error, times out, or returns an invalid response.
+  // Note that requests can be routed only to a subdomain of the original
+  // target, e.g. "us_east_1.cloudbigtable.googleapis.com".
   string default_target = 9;
 
-  // Specify how to process a request when not already in the cache.
-  enum RequestProcessingStrategy {
-    STRATEGY_UNSPECIFIED = 0;
-
-    // Query the RLS and process the request using target returned by the
-    // lookup. The target will then be cached and used for processing
-    // subsequent requests for the same key. Any errors during lookup service
-    // processing will fall back to default target for request processing.
-    SYNC_LOOKUP_DEFAULT_TARGET_ON_ERROR = 1;
-
-    // Query the RLS and process the request using target returned by the
-    // lookup. The target will then be cached and used for processing
-    // subsequent requests for the same key. Any errors during lookup service
-    // processing will return an error back to the client.  Services with
-    // strict regional routing requirements should use this strategy.
-    SYNC_LOOKUP_CLIENT_SEES_ERROR = 2;
-
-    // Query the RLS asynchronously but respond with the default target.  The
-    // target in the lookup response will then be cached and used for
-    // subsequent requests.  Services with strict latency requirements (but not
-    // strict regional routing requirements) should use this strategy.
-    ASYNC_LOOKUP_DEFAULT_TARGET_ON_MISS = 3;
-  }
-  RequestProcessingStrategy request_processing_strategy = 10;
+  reserved 10;
+  reserved "request_processing_strategy";
 }


### PR DESCRIPTION
The RouteLookupResponse.target field was deprecated and is no longer
in use by any server or client, so remove entirely.

The RouteLookupConfig.request_processing_strategy was likewise
deprecated when ASYNC_LOOKUP_DEFAULT_TARGET_ON_MISS stopped being
supported and it became equivalent to just a presence check on
default_target, so remove it now.