### PR TITLE
grpc/testing: add new stats for RPC results and ability to set RPC timeouts dynamically

### DIFF
--- a/grpc/testing/messages.proto
+++ b/grpc/testing/messages.proto
@@ -261,6 +261,9 @@ message ClientConfigureRequest {
   repeated RpcType types = 1;
   // The collection of custom metadata to be attached to RPCs sent by the client.
   repeated Metadata metadata = 2;
+  // The deadline to use, in seconds, for all RPCs.  If unset or zero, the
+  // client will use the default from the command-line.
+  int32 timeout_sec = 3;
 }
 
 // Response for updating a test client's configuration.

--- a/grpc/testing/messages.proto
+++ b/grpc/testing/messages.proto
@@ -219,11 +219,27 @@ message LoadBalancerAccumulatedStatsRequest {}
 // Accumulated stats for RPCs sent by a test client.
 message LoadBalancerAccumulatedStatsResponse {
   // The total number of RPCs have ever issued for each type.
-  map<string, int32> num_rpcs_started_by_method = 1;
+  // Deprecated: use stats_per_method.rpcs_started instead.
+  map<string, int32> num_rpcs_started_by_method = 1 [deprecated = true];
   // The total number of RPCs have ever completed successfully for each type.
-  map<string, int32> num_rpcs_succeeded_by_method = 2;
+  // Deprecated: use stats_per_method.result instead.
+  map<string, int32> num_rpcs_succeeded_by_method = 2 [deprecated = true];
   // The total number of RPCs have ever failed for each type.
-  map<string, int32> num_rpcs_failed_by_method = 3;
+  // Deprecated: use stats_per_method.result instead.
+  map<string, int32> num_rpcs_failed_by_method = 3 [deprecated = true];
+
+  message MethodStats {
+    // The number of RPCs that were started for this method.
+    int32 rpcs_started = 1;
+
+    // The number of RPCs that completed with each status for this method.  The
+    // key is the integral value of a google.rpc.Code; the value is the count.
+    map<int32, int32> result = 2;
+  }
+
+// Per-method RPC statistics.  The key is the full method path; i.e.
+  // "/proto.package.ServiceName/MethodName".
+  map<string, MethodStats> stats_per_method = 4;
 }
 
 // Configurations for a test client.


### PR DESCRIPTION
The newly added "result" map serves the same function as the existing "rpcs succeeded/failed", but also allows for us to verify the *type* of failure; this is necessary for testing that exceeding RPC timeouts results in DEADLINE_EXCEEDED.  The structure (one map from method to a struct) should also be a bit easier to use (multiple maps from method to scalars).
