### PR TITLE
grpc/testing: update docstring of stats_per_method to reflect reality

### DIFF
--- a/grpc/testing/messages.proto
+++ b/grpc/testing/messages.proto
@@ -237,8 +237,8 @@ message LoadBalancerAccumulatedStatsResponse {
     map<int32, int32> result = 2;
   }
 
-  // Per-method RPC statistics.  The key is the full method path; i.e.
-  // "/proto.package.ServiceName/MethodName".
+  // Per-method RPC statistics.  The key is the RpcType in string form; e.g.
+  // 'EMPTY_CALL' or 'UNARY_CALL'
   map<string, MethodStats> stats_per_method = 4;
 }
 


### PR DESCRIPTION
Go and C both implemented this feature using the same key as the existing stats maps in this message: the `RpcType` as a string.  This seems preferable to the full method name, for consistency.  This PR updates the docstring to match that.