### PR TITLE
service config LB policy update

### DIFF
--- a/grpc/service_config/service_config.proto
+++ b/grpc/service_config/service_config.proto
@@ -21,6 +21,10 @@
 // options as the system is likely to choose better values for these options in
 // the vast majority of cases. In other words, please specify a configuration
 // option only if you really have to, and avoid copy-paste inclusion of configs.
+//
+// Note that gRPC uses the service config in JSON form, not in protobuf
+// form.  This proto definition is intended to help document the schema but
+// will not actually be used directly by gRPC.
 
 syntax = "proto3";
 
@@ -190,6 +194,20 @@ message PickFirstConfig {}
 // Configuration for round_robin LB policy.
 message RoundRobinConfig {}
 
+// Configuration for grpclb LB policy.
+message GrpcLbConfig {
+  // Optional.  What LB policy to use for routing between the backend
+  // addresses.  If unset, defaults to round_robin.
+  // Currently, the only supported values are round_robin and pick_first.
+  // Note that this will be used both in balancer mode and in fallback mode.
+  // Multiple LB policies can be specified; clients will iterate through
+  // the list in order and stop at the first policy that they support.
+  repeated LoadBalancingConfig child_policy = 1;
+  // Optional.  If specified, overrides the name of the service to be sent to
+  // the balancer.
+  string service_name = 2;
+}
+
 // Configuration for priority LB policy.
 message PriorityLoadBalancingPolicyConfig {
   // A map of name to child policy configuration.
@@ -198,6 +216,9 @@ message PriorityLoadBalancingPolicyConfig {
   // time it receives a config update.
   message Child {
     repeated LoadBalancingConfig config = 1;
+
+    // If true, will ignore reresolution requests from this child.
+    bool ignore_reresolution_requests = 2;
   }
   map<string, Child> children = 1;
 
@@ -215,47 +236,90 @@ message WeightedTargetLoadBalancingPolicyConfig {
   map<string, Target> targets = 1;
 }
 
-// Configuration for grpclb LB policy.
-message GrpcLbConfig {
-  // Optional.  What LB policy to use for routing between the backend
-  // addresses.  If unset, defaults to round_robin.
-  // Currently, the only supported values are round_robin and pick_first.
-  // Note that this will be used both in balancer mode and in fallback mode.
-  // Multiple LB policies can be specified; clients will iterate through
-  // the list in order and stop at the first policy that they support.
-  repeated LoadBalancingConfig child_policy = 1;
-  // Optional.  If specified, overrides the name of the service to be sent to
-  // the balancer.
-  string service_name = 2;
-}
-
 // Configuration for the cds LB policy.
 message CdsConfig {
   string cluster = 1;  // Required.
 }
 
-// Configuration for xds LB policy.
-message XdsConfig {
-  // Name of balancer to connect to.
-  string balancer_name = 1 [deprecated = true];
-  // Optional.  What LB policy to use for intra-locality routing.
-  // If unset, will use whatever algorithm is specified by the balancer.
-  // Multiple LB policies can be specified; clients will iterate through
-  // the list in order and stop at the first policy that they support.
-  repeated LoadBalancingConfig child_policy = 2;
-  // Optional.  What LB policy to use in fallback mode.  If not
-  // specified, defaults to round_robin.
-  // Multiple LB policies can be specified; clients will iterate through
-  // the list in order and stop at the first policy that they support.
-  repeated LoadBalancingConfig fallback_policy = 3;
-  // Optional.  Name to use in EDS query.  If not present, defaults to
-  // the server name from the target URI.
-  string eds_service_name = 4;
-  // LRS server to send load reports to.
-  // If not present, load reporting will be disabled.
-  // If set to the empty string, load reporting will be sent to the same
-  // server that we obtained CDS data from.
-  google.protobuf.StringValue lrs_load_reporting_server_name = 5;
+// Configuration for xds_cluster_resolver LB policy.
+message XdsClusterResolverLoadBalancingPolicyConfig {
+  // Describes a discovery mechanism instance.
+  // For EDS or LOGICAL_DNS clusters, there will be exactly one
+  // DiscoveryMechanism, which will describe the cluster of the parent
+  // CDS policy.
+  // For aggregate clusters, there will be one DiscoveryMechanism for each
+  // underlying cluster.
+  message DiscoveryMechanism {
+    // Cluster name.
+    string cluster = 1;
+
+    // LRS server to send load reports to.
+    // If not present, load reporting will be disabled.
+    // If set to the empty string, load reporting will be sent to the same
+    // server that we obtained CDS data from.
+    google.protobuf.StringValue lrs_load_reporting_server_name = 2;
+
+    // Maximum number of outstanding requests can be made to the upstream
+    // cluster.  Default is 1024.
+    google.protobuf.UInt32Value max_concurrent_requests = 3;
+
+    enum Type { EDS, LOGICAL_DNS };
+    Type type = 4;
+
+    // For type EDS only.
+    // EDS service name, as returned in CDS.
+    // May be unset if not specified in CDS.
+    string eds_service_name = 5;
+
+    // For type LOGICAL_DNS only.
+    // DNS name to resolve in "host:port" form.
+    string dns_hostname = 6;
+  }
+
+  // Ordered list of discovery mechanisms.
+  // Must have at least one element.
+  // Results from each discovery mechanism are concatenated together in
+  // successive priorities.
+  repeated DiscoveryMechanism discovery_mechanisms = 1;
+
+  // xDS LB policy.
+  // This represents the xDS LB policy, which does not necessarily map
+  // one-to-one to a gRPC LB policy.  Currently, the following policies
+  // are supported:
+  // - "ROUND_ROBIN" (config is empty)
+  // - "RING_HASH" (config is a RingHashLoadBalancingConfig)
+  repeated LoadBalancingConfig xds_lb_policy = 2;
+}
+
+// Configuration for xds_cluster_impl LB policy.
+message XdsClusterImplLoadBalancingPolicyConfig {
+  // Cluster name.  Required.
+  string cluster = 1;
+
+  // EDS service name.
+  // Not set if cluster is not an EDS cluster or if it does not
+  // specify an EDS service name.
+  string eds_service_name = 2;
+
+  // Server to send load reports to.
+  // If unset, no load reporting is done.
+  // If set to empty string, load reporting will be sent to the same
+  // server as we are getting xds data from.
+  google.protobuf.String lrs_load_reporting_server_name = 3;
+
+  // Maximum number of outstanding requests can be made to the upstream cluster.
+  // Default is 1024.
+  google.protobuf.UInt32Value max_concurrent_requests = 4;
+
+  // Drop configuration.
+  message DropCategory {
+    string category = 1;
+    uint32 requests_per_million = 2;
+  }
+  repeated DropCategory drop_categories = 5;
+
+  // Child policy.
+  repeated LoadBalancingConfig child_policy = 6;
 }
 
 // Configuration for eds LB policy.
@@ -288,6 +352,12 @@ message EdsLoadBalancingPolicyConfig {
   repeated LoadBalancingConfig endpoint_picking_policy = 5;
 }
 
+// Configuration for ring_hash LB policy.
+message RingHashLoadBalancingConfig {
+  uint64 min_ring_size = 1;
+  uint64 max_ring_size = 2;
+}
+
 // Configuration for lrs LB policy.
 message LrsLoadBalancingPolicyConfig {
   // Cluster name.  Required.
@@ -312,6 +382,30 @@ message LrsLoadBalancingPolicyConfig {
 
   // Endpoint-picking policy.
   repeated LoadBalancingConfig child_policy = 5;
+}
+
+// Configuration for xds LB policy.
+message XdsConfig {
+  // Name of balancer to connect to.
+  string balancer_name = 1 [deprecated = true];
+  // Optional.  What LB policy to use for intra-locality routing.
+  // If unset, will use whatever algorithm is specified by the balancer.
+  // Multiple LB policies can be specified; clients will iterate through
+  // the list in order and stop at the first policy that they support.
+  repeated LoadBalancingConfig child_policy = 2;
+  // Optional.  What LB policy to use in fallback mode.  If not
+  // specified, defaults to round_robin.
+  // Multiple LB policies can be specified; clients will iterate through
+  // the list in order and stop at the first policy that they support.
+  repeated LoadBalancingConfig fallback_policy = 3;
+  // Optional.  Name to use in EDS query.  If not present, defaults to
+  // the server name from the target URI.
+  string eds_service_name = 4;
+  // LRS server to send load reports to.
+  // If not present, load reporting will be disabled.
+  // If set to the empty string, load reporting will be sent to the same
+  // server that we obtained CDS data from.
+  google.protobuf.StringValue lrs_load_reporting_server_name = 5;
 }
 
 // Selects LB policy and provides corresponding configuration.
@@ -352,23 +446,33 @@ message LoadBalancingConfig {
     // balancing policy.
     GrpcLbConfig grpclb = 3;
 
-    PriorityLoadBalancingPolicyConfig priority = 9;
-    WeightedTargetLoadBalancingPolicyConfig weighted_target = 10;
+    // REMAINING POLICIES ARE EXPERIMENTAL -- DO NOT USE
 
-    // EXPERIMENTAL -- DO NOT USE
+    PriorityLoadBalancingPolicyConfig priority_experimental = 9
+        [json_name = "priority_experimental"];
+    WeightedTargetLoadBalancingPolicyConfig weighted_target_experimental = 10
+        [json_name = "weighted_target_experimental"];
+
     // xDS-based load balancing.
-    // The policy is known as xds_experimental while it is under development.
-    // It will be renamed to xds once it is ready for public use.
-    CdsConfig cds = 6;
-    EdsLoadBalancingPolicyConfig eds = 7;
-    LrsLoadBalancingPolicyConfig lrs = 8;
+    CdsConfig cds_experimental = 6 [json_name = "cds_experimental"];
+    XdsClusterResolverLoadBalancingPolicyConfig
+        xds_cluster_resolver_experimental = 11
+        [json_name = "xds_cluster_resolver_experimental"];
+    XdsClusterImplLoadBalancingPolicyConfig xds_cluster_impl_experimental = 12
+        [json_name = "xds_cluster_impl_experimental"];
+    EdsLoadBalancingPolicyConfig eds_experimental = 7
+        [json_name = "eds_experimental"];
+    RingHashLoadBalancingConfig ring_hash_experimental = 13
+        [json_name = "ring_hash_experimental"];
+
+    // Deprecated xDS-related policies.
+    LrsLoadBalancingPolicyConfig lrs_experimental = 8
+        [json_name = "lrs_experimental", deprecated = true];
     XdsConfig xds = 2 [deprecated = true];
-    // TODO(rekarthik): Deprecate this field after the xds policy
-    // is ready for public use.
     XdsConfig xds_experimental = 5 [json_name = "xds_experimental",
                                     deprecated = true];
 
-    // Next available ID: 11
+    // Next available ID: 14
   }
 }
 

--- a/grpc/service_config/service_config.proto
+++ b/grpc/service_config/service_config.proto
@@ -308,7 +308,7 @@ message XdsClusterImplLoadBalancingPolicyConfig {
   // If unset, no load reporting is done.
   // If set to empty string, load reporting will be sent to the same
   // server as we are getting xds data from.
-  google.protobuf.String lrs_load_reporting_server_name = 3;
+  google.protobuf.StringValue lrs_load_reporting_server_name = 3;
 
   // Maximum number of outstanding requests can be made to the upstream cluster.
   // Default is 1024.

--- a/grpc/service_config/service_config.proto
+++ b/grpc/service_config/service_config.proto
@@ -263,7 +263,10 @@ message XdsClusterResolverLoadBalancingPolicyConfig {
     // cluster.  Default is 1024.
     google.protobuf.UInt32Value max_concurrent_requests = 3;
 
-    enum Type { EDS = 1, LOGICAL_DNS = 2 };
+    enum Type {
+      EDS = 1;
+      LOGICAL_DNS = 2;
+    };
     Type type = 4;
 
     // For type EDS only.

--- a/grpc/service_config/service_config.proto
+++ b/grpc/service_config/service_config.proto
@@ -264,6 +264,7 @@ message XdsClusterResolverLoadBalancingPolicyConfig {
     google.protobuf.UInt32Value max_concurrent_requests = 3;
 
     enum Type {
+      UNKNOWN = 0;
       EDS = 1;
       LOGICAL_DNS = 2;
     };

--- a/grpc/service_config/service_config.proto
+++ b/grpc/service_config/service_config.proto
@@ -263,7 +263,7 @@ message XdsClusterResolverLoadBalancingPolicyConfig {
     // cluster.  Default is 1024.
     google.protobuf.UInt32Value max_concurrent_requests = 3;
 
-    enum Type { EDS, LOGICAL_DNS };
+    enum Type { EDS = 1, LOGICAL_DNS = 2 };
     Type type = 4;
 
     // For type EDS only.


### PR DESCRIPTION
- adds missing "_experimental" prefix to priority and weighted_target policies
- sets proper JSON name for weighted_target policy
- applies changes from [gRFC A37](https://github.com/grpc/proposal/blob/master/A37-xds-aggregate-and-logical-dns-clusters.md) and [gRFC A42](https://github.com/grpc/proposal/blob/master/A42-xds-ring-hash-lb-policy.md)

Fixes #95