### PR TITLE
Add RouteLookupRequest.stale_header_data

### DIFF
--- a/grpc/lookup/v1/rls.proto
+++ b/grpc/lookup/v1/rls.proto
@@ -41,6 +41,8 @@ message RouteLookupRequest {
   }
   // Reason for making this request.
   Reason reason = 5;
+  // For REASON_STALE, the header_data from the stale response, if any.
+  string stale_header_data = 6;
   // Map of key values extracted via key builders for the gRPC or HTTP request.
   map<string, string> key_map = 4;
 }


### PR DESCRIPTION
This field echoes back the RouteLookupResponse.header_data field from
the stale cached value for REASON_STALE requests. This can be helpful,
for example, if the RLS server can prioritize serving stale requests
over new requests.