### PR TITLE
more LB policy config updates

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -209,5 +209,6 @@ proto_library(
         "@com_google_googleapis//google/rpc:code_proto",
         "@com_google_protobuf//:duration_proto",
         "@com_google_protobuf//:wrappers_proto",
+        "@com_google_protobuf//:struct_proto",
     ],
 )

--- a/grpc/service_config/service_config.proto
+++ b/grpc/service_config/service_config.proto
@@ -236,9 +236,33 @@ message WeightedTargetLoadBalancingPolicyConfig {
   map<string, Target> targets = 1;
 }
 
+// Configuration for xds_cluster_manager_experimental LB policy.
+message XdsClusterManagerLoadBalancingPolicyConfig {
+  message Child {
+    repeated LoadBalancingConfig child_policy = 1;
+  }
+  map<string, Child> children = 1;
+}
+
 // Configuration for the cds LB policy.
 message CdsConfig {
   string cluster = 1;  // Required.
+}
+
+// Represents an xDS server.
+message XdsServer {
+  string server_uri = 1 [json_name = "server_uri"];  // Required.
+
+  message ChannelCredentials {
+    string type = 1;  // Required.
+    google.protobuf.Struct config = 2;  // Optional JSON config.
+  }
+  // A list of channel creds to use.  The first supported type will be used.
+  repeated ChannelCredentials channel_creds = 2 [json_name = "channel_creds"];
+
+  // A repeated list of server features.
+  repeated google.protobuf.Value server_features = 3
+      [json_name = "server_features"];
 }
 
 // Configuration for xds_cluster_resolver LB policy.
@@ -257,7 +281,14 @@ message XdsClusterResolverLoadBalancingPolicyConfig {
     // If not present, load reporting will be disabled.
     // If set to the empty string, load reporting will be sent to the same
     // server that we obtained CDS data from.
-    google.protobuf.StringValue lrs_load_reporting_server_name = 2;
+    // DEPRECATED: Use new lrs_load_reporting_server field instead.
+    google.protobuf.StringValue lrs_load_reporting_server_name = 2
+        [deprecated=true];
+
+    // LRS server to send load reports to.
+    // If not present, load reporting will be disabled.
+    // Supercedes lrs_load_reporting_server_name field.
+    XdsServer lrs_load_reporting_server = 7;
 
     // Maximum number of outstanding requests can be made to the upstream
     // cluster.  Default is 1024.
@@ -309,7 +340,14 @@ message XdsClusterImplLoadBalancingPolicyConfig {
   // If unset, no load reporting is done.
   // If set to empty string, load reporting will be sent to the same
   // server as we are getting xds data from.
-  google.protobuf.StringValue lrs_load_reporting_server_name = 3;
+  // DEPRECATED: Use new lrs_load_reporting_server field instead.
+  google.protobuf.StringValue lrs_load_reporting_server_name = 3
+      [deprecated=true];
+
+  // LRS server to send load reports to.
+  // If not present, load reporting will be disabled.
+  // Supercedes lrs_load_reporting_server_name field.
+  XdsServer lrs_load_reporting_server = 7;
 
   // Maximum number of outstanding requests can be made to the upstream cluster.
   // Default is 1024.
@@ -458,20 +496,22 @@ message LoadBalancingConfig {
         [json_name = "weighted_target_experimental"];
 
     // xDS-based load balancing.
+    XdsClusterManagerLoadBalancingPolicyConfig xds_cluster_manager_experimental
+        = 14 [json_name = "xds_cluster_manager_experimental"];
     CdsConfig cds_experimental = 6 [json_name = "cds_experimental"];
     XdsClusterResolverLoadBalancingPolicyConfig
         xds_cluster_resolver_experimental = 11
         [json_name = "xds_cluster_resolver_experimental"];
     XdsClusterImplLoadBalancingPolicyConfig xds_cluster_impl_experimental = 12
         [json_name = "xds_cluster_impl_experimental"];
-    EdsLoadBalancingPolicyConfig eds_experimental = 7
-        [json_name = "eds_experimental"];
     RingHashLoadBalancingConfig ring_hash_experimental = 13
         [json_name = "ring_hash_experimental"];
 
     // Deprecated xDS-related policies.
     LrsLoadBalancingPolicyConfig lrs_experimental = 8
         [json_name = "lrs_experimental", deprecated = true];
+    EdsLoadBalancingPolicyConfig eds_experimental = 7
+        [json_name = "eds_experimental", deprecated = true];
     XdsConfig xds = 2 [deprecated = true];
     XdsConfig xds_experimental = 5 [json_name = "xds_experimental",
                                     deprecated = true];

--- a/grpc/service_config/service_config.proto
+++ b/grpc/service_config/service_config.proto
@@ -31,6 +31,7 @@ syntax = "proto3";
 package grpc.service_config;
 
 import "google/protobuf/duration.proto";
+import "google/protobuf/struct.proto";
 import "google/protobuf/wrappers.proto";
 import "google/rpc/code.proto";
 


### PR DESCRIPTION
- Add `XdsServer` message and use it in new fields in `xds_cluster_resolver_experimental` and `xds_cluster_impl_experimental` configs, as per the latest draft of grpc/proposal#268
- Deprecate `eds_experimental` policy config, as per [gRFC A37](https://github.com/grpc/proposal/blob/master/A37-xds-aggregate-and-logical-dns-clusters.md)
- Add missing config for `xds_cluster_manager_experimental` policy, as per [gRFC A31](https://github.com/grpc/proposal/blob/master/A31-xds-timeout-support-and-config-selector.md)