### PR TITLE
Add common java options to the testing/*.protos. 

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -28,10 +28,22 @@ proto_library(
     srcs = ["grpc/testing/messages.proto"],
 )
 
+java_proto_library(
+    name = "messages_java_proto",
+    visibility = ["//visibility:public"],
+    deps = [":messages_proto"],
+)
+
 proto_library(
     name = "benchmark_service_proto",
     srcs = ["grpc/testing/benchmark_service.proto"],
     deps = [":messages_proto"],
+)
+
+java_proto_library(
+    name = "benchmark_service_java_proto",
+    visibility = ["//visibility:public"],
+    deps = [":benchmark_service_proto"],
 )
 
 proto_library(
@@ -44,10 +56,22 @@ proto_library(
     deps = [":stats_proto"],
 )
 
+java_proto_library(
+    name = "control_java_proto",
+    visibility = ["//visibility:public"],
+    deps = [":control_proto"],
+)
+
 proto_library(
     name = "report_qps_scenario_service_proto",
     srcs = ["grpc/testing/report_qps_scenario_service.proto"],
     deps = [":control_proto"],
+)
+
+java_proto_library(
+    name = "report_qps_scenario_service_java_proto",
+    visibility = ["//visibility:public"],
+    deps = [":report_qps_scenario_service_proto"],
 )
 
 proto_library(
@@ -58,6 +82,12 @@ proto_library(
     deps = [
         ":control_proto",
     ],
+)
+
+java_proto_library(
+    name = "worker_service_java_proto",
+    visibility = ["//visibility:public"],
+    deps = [":worker_service_proto"],
 )
 
 proto_library(

--- a/grpc/testing/benchmark_service.proto
+++ b/grpc/testing/benchmark_service.proto
@@ -20,6 +20,10 @@ import "grpc/testing/messages.proto";
 
 package grpc.testing;
 
+option java_multiple_files = true;
+option java_package = "io.grpc.testing";
+option java_outer_classname = "BenchmarkServiceProto";
+
 service BenchmarkService {
   // One request followed by one response.
   // The server returns the client payload as-is.

--- a/grpc/testing/control.proto
+++ b/grpc/testing/control.proto
@@ -19,6 +19,10 @@ import "grpc/testing/stats.proto";
 
 package grpc.testing;
 
+option java_multiple_files = true;
+option java_package = "io.grpc.testing";
+option java_outer_classname = "ControlProto";
+
 enum ClientType {
   // Many languages support a basic distinction between using
   // sync or async client, and this allows the specification

--- a/grpc/testing/empty.proto
+++ b/grpc/testing/empty.proto
@@ -17,6 +17,10 @@ syntax = "proto3";
 
 package grpc.testing;
 
+option java_multiple_files = true;
+option java_package = "io.grpc.testing";
+option java_outer_classname = "EmptyProto";
+
 // An empty message that you can re-use to avoid defining duplicated empty
 // messages in your project. A typical example is to use it as argument or the
 // return value of a service API. For instance:

--- a/grpc/testing/empty.proto
+++ b/grpc/testing/empty.proto
@@ -17,9 +17,8 @@ syntax = "proto3";
 
 package grpc.testing;
 
-option java_multiple_files = true;
-option java_package = "io.grpc.testing";
-option java_outer_classname = "EmptyProto";
+option java_package = "io.grpc.testing.integration";
+option java_outer_classname = "EmptyProtos";
 
 // An empty message that you can re-use to avoid defining duplicated empty
 // messages in your project. A typical example is to use it as argument or the

--- a/grpc/testing/messages.proto
+++ b/grpc/testing/messages.proto
@@ -19,6 +19,10 @@ syntax = "proto3";
 
 package grpc.testing;
 
+option java_multiple_files = true;
+option java_package = "io.grpc.testing";
+option java_outer_classname = "MessagesProto";
+
 // TODO(dgq): Go back to using well-known types once
 // https://github.com/grpc/grpc/issues/6980 has been fixed.
 // import "google/protobuf/wrappers.proto";

--- a/grpc/testing/messages.proto
+++ b/grpc/testing/messages.proto
@@ -19,9 +19,7 @@ syntax = "proto3";
 
 package grpc.testing;
 
-option java_multiple_files = true;
-option java_package = "io.grpc.testing";
-option java_outer_classname = "MessagesProto";
+option java_package = "io.grpc.testing.integration";
 
 // TODO(dgq): Go back to using well-known types once
 // https://github.com/grpc/grpc/issues/6980 has been fixed.

--- a/grpc/testing/payloads.proto
+++ b/grpc/testing/payloads.proto
@@ -16,6 +16,10 @@ syntax = "proto3";
 
 package grpc.testing;
 
+option java_multiple_files = true;
+option java_package = "io.grpc.testing";
+option java_outer_classname = "PayloadsProto";
+
 message ByteBufferParams {
   int32 req_size = 1;
   int32 resp_size = 2;

--- a/grpc/testing/report_qps_scenario_service.proto
+++ b/grpc/testing/report_qps_scenario_service.proto
@@ -20,6 +20,10 @@ import "grpc/testing/control.proto";
 
 package grpc.testing;
 
+option java_multiple_files = true;
+option java_package = "io.grpc.testing";
+option java_outer_classname = "ReportQpsScenarioServiceProto";
+
 service ReportQpsScenarioService {
   // Report results of a QPS test benchmark scenario.
   rpc ReportScenario(ScenarioResult) returns (Void);

--- a/grpc/testing/stats.proto
+++ b/grpc/testing/stats.proto
@@ -18,6 +18,10 @@ package grpc.testing;
 
 import "grpc/core/stats.proto";
 
+option java_multiple_files = true;
+option java_package = "io.grpc.testing";
+option java_outer_classname = "StatsProto";
+
 message ServerStats {
   // wall clock time change in seconds since last reset
   double time_elapsed = 1;

--- a/grpc/testing/test.proto
+++ b/grpc/testing/test.proto
@@ -23,6 +23,10 @@ import "grpc/testing/messages.proto";
 
 package grpc.testing;
 
+option java_multiple_files = true;
+option java_package = "io.grpc.testing";
+option java_outer_classname = "TestProto";
+
 // A simple service to test the various types of RPCs and experiment with
 // performance with various types of payload.
 service TestService {

--- a/grpc/testing/test.proto
+++ b/grpc/testing/test.proto
@@ -23,9 +23,7 @@ import "grpc/testing/messages.proto";
 
 package grpc.testing;
 
-option java_multiple_files = true;
-option java_package = "io.grpc.testing";
-option java_outer_classname = "TestProto";
+option java_package = "io.grpc.testing.integration";
 
 // A simple service to test the various types of RPCs and experiment with
 // performance with various types of payload.

--- a/grpc/testing/worker_service.proto
+++ b/grpc/testing/worker_service.proto
@@ -20,6 +20,10 @@ import "grpc/testing/control.proto";
 
 package grpc.testing;
 
+option java_multiple_files = true;
+option java_package = "io.grpc.testing";
+option java_outer_classname = "WorkerServiceProto";
+
 service WorkerService {
   // Start server with specified workload.
   // First request sent specifies the ServerConfig followed by ServerStatus


### PR DESCRIPTION
This PR adds common java proto options to the testing files.

Particularly the 3 main options include

* Java multiple files = true
* Java package which is being set to io.grpc.testing
* Java outer classname which is being set to fileNameProto

