### PR TITLE
Add go_package to reflection v1alpha

### DIFF
--- a/grpc/reflection/v1alpha/reflection.proto
+++ b/grpc/reflection/v1alpha/reflection.proto
@@ -22,6 +22,7 @@ syntax = "proto3";
 package grpc.reflection.v1alpha;
 
 option deprecated = true;
+option go_package = "google.golang.org/grpc/reflection/grpc_reflection_v1alpha";
 option java_multiple_files = true;
 option java_package = "io.grpc.reflection.v1alpha";
 option java_outer_classname = "ServerReflectionProto";


### PR DESCRIPTION
Adding option to reflection v1alpha to allow go files to be generated from this repository.

With this change, we can remove the duplicate copy of reflection (v1alpha) from the grpc/grpc-go repository.

Referenced in https://github.com/grpc/grpc-go/issues/5684.