### PR TITLE
add RLS LB policy config

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -239,6 +239,7 @@ proto_library(
     srcs = ["grpc/service_config/service_config.proto"],
     visibility = ["//visibility:public"],
     deps = [
+        ":rls_config_proto",
         "@com_google_googleapis//google/rpc:code_proto",
         "@com_google_protobuf//:duration_proto",
         "@com_google_protobuf//:wrappers_proto",

--- a/grpc/service_config/service_config.proto
+++ b/grpc/service_config/service_config.proto
@@ -34,6 +34,7 @@ import "google/protobuf/duration.proto";
 import "google/protobuf/struct.proto";
 import "google/protobuf/wrappers.proto";
 import "google/rpc/code.proto";
+import "grpc/lookup/v1/rls_config.proto";
 
 option java_package = "io.grpc.serviceconfig";
 option java_multiple_files = true;
@@ -328,6 +329,18 @@ message WeightedTargetLoadBalancingPolicyConfig {
   map<string, Target> targets = 1;
 }
 
+// Config for RLS LB policy.
+message RlsLoadBalancingPolicyConfig {
+  // Route lookup config.
+  grpc.lookup.v1.RouteLookupConfig route_lookup_config = 1;
+  // Service config to use for the RLS channel.
+  ServiceConfig route_lookup_channel_service_config = 2;
+  // Child policy config.
+  repeated LoadBalancingConfig child_policy = 3;
+  // Field name to add to child policy config to contain the target name.
+  string child_policy_config_target_field_name = 4;
+}
+
 // Configuration for xds_cluster_manager_experimental LB policy.
 message XdsClusterManagerLoadBalancingPolicyConfig {
   message Child {
@@ -584,8 +597,6 @@ message LoadBalancingConfig {
 
     RoundRobinConfig round_robin = 1 [json_name = "round_robin"];
 
-    OutlierDetectionLoadBalancingConfig outlier_detection = 15 [json_name = "outlier_detection"];
-
     // gRPC lookaside load balancing.
     // This will eventually be deprecated by the new xDS-based local
     // balancing policy.
@@ -597,6 +608,9 @@ message LoadBalancingConfig {
         [json_name = "priority_experimental"];
     WeightedTargetLoadBalancingPolicyConfig weighted_target_experimental = 10
         [json_name = "weighted_target_experimental"];
+    OutlierDetectionLoadBalancingConfig outlier_detection = 15
+        [json_name = "outlier_detection_experimental"];
+    RlsLoadBalancingPolicyConfig rls = 18 [json_name = "rls_experimental"];
 
     // xDS-based load balancing.
     XdsClusterManagerLoadBalancingPolicyConfig xds_cluster_manager_experimental
@@ -607,8 +621,12 @@ message LoadBalancingConfig {
         [json_name = "xds_cluster_resolver_experimental"];
     XdsClusterImplLoadBalancingPolicyConfig xds_cluster_impl_experimental = 12
         [json_name = "xds_cluster_impl_experimental"];
+    XdsWrrLocalityLoadBalancingPolicyConfig xds_wrr_locality_experimental = 16
+        [json_name = "xds_wrr_locality_experimental"];
     RingHashLoadBalancingConfig ring_hash_experimental = 13
         [json_name = "ring_hash_experimental"];
+    LeastRequestLocalityLoadBalancingPolicyConfig least_request_experimental =
+        17 [json_name = "least_request_experimental"];
 
     // Deprecated xDS-related policies.
     LrsLoadBalancingPolicyConfig lrs_experimental = 8
@@ -618,12 +636,8 @@ message LoadBalancingConfig {
     XdsConfig xds = 2 [deprecated = true];
     XdsConfig xds_experimental = 5 [json_name = "xds_experimental",
                                     deprecated = true];
-    XdsWrrLocalityLoadBalancingPolicyConfig xds_wrr_locality_experimental = 16
-      [json_name = "xds_wrr_locality_experimental"];
-    LeastRequestLocalityLoadBalancingPolicyConfig least_request_experimental = 17
-      [json_name = "least_request_experimental"];
 
-    // Next available ID: 18
+    // Next available ID: 19
   }
 }
 

--- a/grpc/service_config/service_config.proto
+++ b/grpc/service_config/service_config.proto
@@ -331,11 +331,11 @@ message WeightedTargetLoadBalancingPolicyConfig {
 
 // Config for RLS LB policy.
 message RlsLoadBalancingPolicyConfig {
-  // Route lookup config.
   grpc.lookup.v1.RouteLookupConfig route_lookup_config = 1;
+
   // Service config to use for the RLS channel.
   ServiceConfig route_lookup_channel_service_config = 2;
-  // Child policy config.
+
   repeated LoadBalancingConfig child_policy = 3;
   // Field name to add to child policy config to contain the target name.
   string child_policy_config_target_field_name = 4;

--- a/grpc/service_config/service_config.proto
+++ b/grpc/service_config/service_config.proto
@@ -633,7 +633,7 @@ message LoadBalancingConfig {
         [json_name = "weighted_target_experimental"];
     OutlierDetectionLoadBalancingConfig outlier_detection = 15
         [json_name = "outlier_detection_experimental"];
-    RlsLoadBalancingPolicyConfig rls = 18 [json_name = "rls_experimental"];
+    RlsLoadBalancingPolicyConfig rls = 19 [json_name = "rls_experimental"];
 
     // xDS-based load balancing.
     XdsClusterManagerLoadBalancingPolicyConfig xds_cluster_manager_experimental
@@ -662,7 +662,7 @@ message LoadBalancingConfig {
     XdsConfig xds_experimental = 5 [json_name = "xds_experimental",
                                     deprecated = true];
 
-    // Next available ID: 19
+    // Next available ID: 20
   }
 }
 

--- a/grpc/service_config/service_config.proto
+++ b/grpc/service_config/service_config.proto
@@ -500,8 +500,11 @@ message EdsLoadBalancingPolicyConfig {
 
 // Configuration for ring_hash LB policy.
 message RingHashLoadBalancingConfig {
-  uint64 min_ring_size = 1;
-  uint64 max_ring_size = 2;
+  // A client-side option will cap these values to 4096.  If either of these
+  // values are greater than the client-side cap, they will be treated
+  // as the client-side cap value.
+  uint64 min_ring_size = 1;  // Optional, defaults to 1024, max 8M.
+  uint64 max_ring_size = 2;  // Optional, defaults to 4096, max 8M.
 }
 
 // Configuration for lrs LB policy.


### PR DESCRIPTION
Also a couple of other cleanups:
- Add the missing `_experimental` suffix to the outlier detection config.
- Reorganize the fields a bit to be under the right comment headings.
- Add comments on the ring_hash min/max ring size fields matching the behavior described in https://github.com/grpc/proposal/pull/338.