### PR TITLE
grpc/testing: update `PayloadType` enum

### DIFF
--- a/grpc/testing/messages.proto
+++ b/grpc/testing/messages.proto
@@ -33,6 +33,12 @@ message BoolValue {
 enum PayloadType {
   // Compressable text format.
   COMPRESSABLE = 0;
+
+  // Uncompressable binary format.
+  UNCOMPRESSABLE = 1;
+
+  // Randomly chosen from all other formats defined in this enum.
+  RANDOM = 2;
 }
 
 // A block of data, to simply increase gRPC message size.


### PR DESCRIPTION
`PayloadType` enum found in testing protos defined elsewhere contain two more entries. Currently, in the grpc-go repo, we have our own testing.proto which is a subset of the protos found here, except for the fact that it has two more entries in the `PayloadType` enum. Adding the two entries here would enable grpc-go to get rid of our own copy of the proto and rely on the canonical proto from here.