### PR TITLE
Set permissions for GitHub Actions

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -7,6 +7,9 @@ on:
   push:
   pull_request:
 
+permissions:
+  contents: read
+
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   # This workflow contains a single job called "build"


### PR DESCRIPTION
GitHub Actions has really, really bad default permissions, including write. This can be changed in the repository settings, but that doesn't protect forks and is harder to verify. Set the permissions actually needed by the testing workflow to avoid Actions accidentally having more power than they should.