### PR TITLE
fix typo in grpc/testing/messaging.proto

### DIFF
--- a/grpc/testing/messages.proto
+++ b/grpc/testing/messages.proto
@@ -219,7 +219,7 @@ message LoadBalancerStatsResponse {
   message RpcMetadata {
     // metadata values for each rpc for the keys specified in
     // LoadBalancerStatsRequest.metadata_keys.
-    // metadata keys and values are returned exactly as was recieved
+    // metadata keys and values are returned exactly as was received
     // from the server.
     repeated MetadataEntry metadata = 1;
   }


### PR DESCRIPTION
This typo is breaking our vet test.