### PR TITLE
Add application-specific optional `extensions` fields to rls.proto

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -213,6 +213,7 @@ proto_library(
     name = "rls_proto",
     srcs = ["grpc/lookup/v1/rls.proto"],
     visibility = ["//visibility:public"],
+    deps = ["@com_google_protobuf//:any_proto"],
 )
 
 java_proto_library(

--- a/grpc/lookup/v1/rls.proto
+++ b/grpc/lookup/v1/rls.proto
@@ -16,6 +16,8 @@ syntax = "proto3";
 
 package grpc.lookup.v1;
 
+import "google/protobuf/any.proto";
+
 option go_package = "google.golang.org/grpc/lookup/grpc_lookup_v1";
 option java_multiple_files = true;
 option java_package = "io.grpc.lookup.v1";
@@ -38,7 +40,7 @@ message RouteLookupRequest {
   // Map of key values extracted via key builders for the gRPC or HTTP request.
   map<string, string> key_map = 4;
   // Application-specific optional extensions.
-  repeated Any extensions = 5;
+  repeated google.protobuf.Any extensions = 7;
 
   reserved 1, 2;
   reserved "server", "path";
@@ -54,7 +56,7 @@ message RouteLookupResponse {
   // Allows the RLS to pass its work product to the eventual target.
   string header_data = 2;
   // Application-specific optional extensions.
-  repeated Any extensions = 4;  
+  repeated google.protobuf.Any extensions = 4;
 
   reserved 1;
   reserved "target";


### PR DESCRIPTION
Add  application-specific optional `extensions` fields to `RouteLookupRequest` and `RouteLookupResponse` proto messages.