### PR TITLE
Improve documentation comments for health service

### DIFF
--- a/grpc/health/v1/health.proto
+++ b/grpc/health/v1/health.proto
@@ -39,9 +39,19 @@ message HealthCheckResponse {
   ServingStatus status = 1;
 }
 
+// Health is gRPC's mechanism for checking whether a server is able to handle
+// RPCs. Its semantics are documented in
+// https://github.com/grpc/grpc/blob/master/doc/health-checking.md.
 service Health {
-  // If the requested service is unknown, the call will fail with status
-  // NOT_FOUND.
+  // Check gets the health of the specified service. If the requested service
+  // is unknown, the call will fail with status NOT_FOUND. If the caller does
+  // not specify a service name, the server should respond with its overall
+  // health status.
+  //
+  // Clients should set a deadline when calling Check, and can declare the
+  // server unhealthy if they do not receive a timely response.
+  //
+  // Check implementations should be idempotent and side effect free.
   rpc Check(HealthCheckRequest) returns (HealthCheckResponse);
 
   // Performs a watch for the serving status of the requested service.


### PR DESCRIPTION
This commit somewhat improves the documentation of `grpc.health.v1.Health`:

- It directs readers to [the specification](https://github.com/grpc/grpc/blob/master/doc/health-checking.md), which feels a bit too long to inline into comments.
- It explains the semantics of the `Check` RPC a bit more thoroughly, clarifying that implementations should be idempotent and side effect free.

Hopefully, this PR faithfully follows the discussion with @ejona86 in #127.
