### PR TITLE
[xds test] Add ReturnAll method to a HookServer

### DIFF
--- a/grpc/testing/messages.proto
+++ b/grpc/testing/messages.proto
@@ -319,6 +319,14 @@ message TestOrcaReport {
   map<string, double> utilization = 4;
 }
 
+// Request to a ReturnAll method of the HookService. Specifies the status
+// that will be returned to all pending hook requests as well as hook requests
+// that will arrive after this call.
+message ReturnAllRequest {
+  int32 grpc_code_to_return = 1;
+  string grpc_status_description = 2;
+}
+
 message HookRequest {
   enum HookRequestCommand {
     // Default value

--- a/grpc/testing/messages.proto
+++ b/grpc/testing/messages.proto
@@ -319,10 +319,8 @@ message TestOrcaReport {
   map<string, double> utilization = 4;
 }
 
-// Request to a ReturnAll method of the HookService. Specifies the status
-// that will be returned to all pending hook requests as well as hook requests
-// that will arrive after this call.
-message ReturnAllRequest {
+// Status that will be return to callers of the Hook method
+message SetReturnStatusRequest {
   int32 grpc_code_to_return = 1;
   string grpc_status_description = 2;
 }

--- a/grpc/testing/test.proto
+++ b/grpc/testing/test.proto
@@ -91,8 +91,7 @@ service LoadBalancerStatsService {
       returns (LoadBalancerAccumulatedStatsResponse) {}
 }
 
-// Hook service. Used to keep a connection alive so Kubernates does not shut
-// down the pod.
+// Hook service. Used to keep Kubernetes from shutting the pod down.
 service HookService {
   // Sends a request that will "hang" until the return status is set by a call
   // to a SetReturnStatus

--- a/grpc/testing/test.proto
+++ b/grpc/testing/test.proto
@@ -95,6 +95,7 @@ service LoadBalancerStatsService {
 // with HookRequestCommand::START
 service HookService {
   rpc Hook(grpc.testing.Empty) returns (grpc.testing.Empty);
+  rpc ReturnAll(ReturnAllRequest) returns (grpc.testing.Empty);
 }
 
 // A service to remotely control health status of an xDS test server.

--- a/grpc/testing/test.proto
+++ b/grpc/testing/test.proto
@@ -91,11 +91,16 @@ service LoadBalancerStatsService {
       returns (LoadBalancerAccumulatedStatsResponse) {}
 }
 
-// Hook service that may be started on request by calling XdsUpdateHealthService
-// with HookRequestCommand::START
+// Hook service. Used to keep a connection alive so Kubernates does not shut
+// down the pod.
 service HookService {
+  // Sends a request that will "hang" until the return status is set by a call
+  // to a SetReturnStatus
   rpc Hook(grpc.testing.Empty) returns (grpc.testing.Empty);
-  rpc ReturnAll(ReturnAllRequest) returns (grpc.testing.Empty);
+  // Sets a return status for pending and upcoming calls to Hook
+  rpc SetReturnStatus(SetReturnStatusRequest) returns (grpc.testing.Empty);
+  // Clears the return status. Incoming calls to Hook will "hang"
+  rpc ClearReturnStatus(grpc.testing.Empty) returns (grpc.testing.Empty);
 }
 
 // A service to remotely control health status of an xDS test server.


### PR DESCRIPTION
I propose to add a ReturnAll method to a Hook server. This replaces the HookRequest with the Return method. Ultimately, this would allow us to completely remove the SendHookRequest method from the XdsUpdateHealthService when the tests no longer rely on it.