### PR TITLE
Upgrade protobuf to 24.4

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,0 +1,1 @@
+build --cxxopt=-std=c++14 --host_cxxopt=-std=c++14

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -19,9 +19,9 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
     name = "com_google_protobuf",
-    sha256 = "33cba8b89be6c81b1461f1c438424f7a1aa4e31998dbe9ed6f8319583daac8c7",
-    strip_prefix = "protobuf-3.10.0",
-    urls = ["https://github.com/protocolbuffers/protobuf/archive/v3.10.0.zip"],
+    sha256 = "616bb3536ac1fff3fb1a141450fa28b875e985712170ea7f1bfe5e5fc41e2cd8",
+    strip_prefix = "protobuf-24.4",
+    urls = ["https://github.com/protocolbuffers/protobuf/releases/download/v24.4/protobuf-24.4.tar.gz"],
 )
 
 load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")


### PR DESCRIPTION
-std=c++14 is required by absl to increase the c++ version on multiple supported platforms.

CC @matthewstevenson88

Protobuf 25 drops support for Bazel 5. But 24 is still a relatively recent version and it gets us past the absl addition.