### PR TITLE
Add List method to gRPC Health service

### DIFF
--- a/grpc/health/v1/health.proto
+++ b/grpc/health/v1/health.proto
@@ -40,9 +40,7 @@ message HealthCheckResponse {
   ServingStatus status = 1;
 }
 
-message HealthListRequest {
-  repeated string services = 1; // Contains the name of the services that should be obtained. If empty, must returns all.
-}
+message HealthListRequest {}
 
 message HealthListResponse {
   map<string, HealthCheckResponse> statuses = 1; // Contains all the services and their respective status.
@@ -63,18 +61,19 @@ service Health {
   // Check implementations should be idempotent and side effect free.
   rpc Check(HealthCheckRequest) returns (HealthCheckResponse);
 
-  // List gets the health of all the available services. A filtered list can
-  // be obtained by sending the list of the respective service names. If the
-  // list of service names is empty, all the available services must be returned.
+  // List provides a non-atomic snapshot of the health of all the available services.
   //
-  // Use case: Integrate servers and status report dashboards.
+  // The maximum number of services to return is 100; responses exceeding this limit will result in a RESOURCE_EXHAUSTED
+  // error.
   //
   // Clients should set a deadline when calling List, and can declare the
   // server unhealthy if they do not receive a timely response.
   //
+  // Clients should keep in mind that the list of health services exposed by an application
+  // can change over the lifetime of the process.
   //
   // List implementations should be idempotent and side effect free.
-  rpc List(HealthListRequest) returns (HealthCheckResponse);
+  rpc List(HealthListRequest) returns (HealthListResponse);
 
   // Performs a watch for the serving status of the requested service.
   // The server will immediately send back a message indicating the current

--- a/grpc/health/v1/health.proto
+++ b/grpc/health/v1/health.proto
@@ -44,7 +44,7 @@ message HealthListRequest {
 }
 
 message HealthListResponse {
-  map<string, HealthCheckResponse> services_statuses = 2; // Contains all the service and their respective status.
+  map<string, HealthCheckResponse> statuses = 1; // Contains all the services and their respective status.
 }
 
 // Health is gRPC's mechanism for checking whether a server is able to handle
@@ -64,7 +64,7 @@ service Health {
 
   // List gets the health of all the available services. A filtered list can
   // be obtained by sending the list of the respective service names. If the
-  // list of service names is empty must return all the available services.
+  // list of service names is empty, all the available services must be returned.
   //
   // Use case: Integrate servers and status report dashboards.
   //

--- a/grpc/health/v1/health.proto
+++ b/grpc/health/v1/health.proto
@@ -39,6 +39,14 @@ message HealthCheckResponse {
   ServingStatus status = 1;
 }
 
+message HealthListRequest {
+  repeated string services = 1; // Contains the name of the services that should be obtained. If empty, must returns all.
+}
+
+message HealthListResponse {
+  map<string, HealthCheckResponse> services_statuses = 2; // Contains all the service and their respective status.
+}
+
 // Health is gRPC's mechanism for checking whether a server is able to handle
 // RPCs. Its semantics are documented in
 // https://github.com/grpc/grpc/blob/master/doc/health-checking.md.
@@ -53,6 +61,19 @@ service Health {
   //
   // Check implementations should be idempotent and side effect free.
   rpc Check(HealthCheckRequest) returns (HealthCheckResponse);
+
+  // List gets the health of all the available services. A filtered list can
+  // be obtained by sending the list of the respective service names. If the
+  // list of service names is empty must return all the available services.
+  //
+  // Use case: Integrate servers and status report dashboards.
+  //
+  // Clients should set a deadline when calling List, and can declare the
+  // server unhealthy if they do not receive a timely response.
+  //
+  //
+  // List implementations should be idempotent and side effect free.
+  rpc List(HealthListRequest) returns (HealthCheckResponse);
 
   // Performs a watch for the serving status of the requested service.
   // The server will immediately send back a message indicating the current

--- a/grpc/health/v1/health.proto
+++ b/grpc/health/v1/health.proto
@@ -43,7 +43,8 @@ message HealthCheckResponse {
 message HealthListRequest {}
 
 message HealthListResponse {
-  map<string, HealthCheckResponse> statuses = 1; // Contains all the services and their respective status.
+  // statuses contains all the services and their respective status.
+  map<string, HealthCheckResponse> statuses = 1;
 }
 
 // Health is gRPC's mechanism for checking whether a server is able to handle
@@ -57,22 +58,19 @@ service Health {
   //
   // Clients should set a deadline when calling Check, and can declare the
   // server unhealthy if they do not receive a timely response.
-  //
-  // Check implementations should be idempotent and side effect free.
   rpc Check(HealthCheckRequest) returns (HealthCheckResponse);
 
-  // List provides a non-atomic snapshot of the health of all the available services.
+  // List provides a non-atomic snapshot of the health of all the available
+  // services.
   //
-  // The maximum number of services to return is 100; responses exceeding this limit will result in a RESOURCE_EXHAUSTED
-  // error.
+  // The maximum number of services to return is 100; if responses contain more
+  // than this limit, it will result in a RESOURCE_EXHAUSTED error.
   //
-  // Clients should set a deadline when calling List, and can declare the
-  // server unhealthy if they do not receive a timely response.
+  // Clients should set a deadline when calling List, and can declare the server
+  // unhealthy if they do not receive a timely response.
   //
-  // Clients should keep in mind that the list of health services exposed by an application
-  // can change over the lifetime of the process.
-  //
-  // List implementations should be idempotent and side effect free.
+  // Clients should keep in mind that the list of health services exposed by an
+  // application can change over the lifetime of the process.
   rpc List(HealthListRequest) returns (HealthListResponse);
 
   // Performs a watch for the serving status of the requested service.

--- a/grpc/health/v1/health.proto
+++ b/grpc/health/v1/health.proto
@@ -63,8 +63,8 @@ service Health {
   // List provides a non-atomic snapshot of the health of all the available
   // services.
   //
-  // The maximum number of services to return is 100; if responses contain more
-  // than this limit, it will result in a RESOURCE_EXHAUSTED error.
+  // The server may respond with a RESOURCE_EXHAUSTED error if too many services
+  // exist.
   //
   // Clients should set a deadline when calling List, and can declare the server
   // unhealthy if they do not receive a timely response.


### PR DESCRIPTION
# Context
Clients cannot get a list of the services a certain server is watching to and their respective status.

In the context of Kubernetes, we have `livez` and `readyz` endpoints, by listing all the services a server is checking, we could return a response like the `/readyz?verbose` Kubernetes API returns:

```
[+]ping ok
[+]log ok
[+]etcd ok
[+]poststarthook/start-kube-apiserver-admission-initializer ok
[+]poststarthook/generic-apiserver-start-informers ok
[+]poststarthook/start-apiextensions-informers ok
[+]poststarthook/start-apiextensions-controllers ok
[+]poststarthook/crd-informer-synced ok
[+]poststarthook/bootstrap-controller ok
[+]poststarthook/rbac/bootstrap-roles ok
[+]poststarthook/scheduling/bootstrap-system-priority-classes ok
[+]poststarthook/start-cluster-authentication-info-controller ok
[+]poststarthook/start-kube-aggregator-informers ok
[+]poststarthook/apiservice-registration-controller ok
[+]poststarthook/apiservice-status-available-controller ok
[+]poststarthook/kube-apiserver-autoregistration ok
[+]autoregister-completion ok
[+]poststarthook/apiservice-openapi-controller ok
healthz check passed
```

# Use case
This is not only useful for having status reports like Kubernetes `readyz` endpoints; it also allows services to simplify the set up when creating microservices that publish their status to status page systems such as: 
- https://cachethq.io/
- https://www.atlassian.com/software/statuspage

# Change
This PR introduces a new `List` endpoint to the `Health` service in order to list all the services that a certain server is watching to.

# Alternative solution
We could extract the `List` endpoint into a new service to avoid breaking the `v1` API. A new `HealthLister` (or any other name) must be created.

# Proposal
https://github.com/grpc/proposal/pull/468