### PR TITLE
Correct module name

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,5 +1,5 @@
 module(
-    name = "grpc_proto",
+    name = "grpc-proto",
     version = "0.0.0",
     repo_name = "io_grpc_grpc_proto",
 )


### PR DESCRIPTION
The module name was wrongly named first, it shall be aligned with the project name as it is done for other grpc bazel modules