### PR TITLE
Add bazel targets for s2a proto files

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -247,3 +247,34 @@ proto_library(
         "@com_google_protobuf//:wrappers_proto",
     ],
 )
+
+proto_library(
+    name = "s2a_common_proto",
+    srcs = [
+        "grpc/gcp/s2a/common.proto",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+proto_library(
+    name = "s2a_context_proto",
+    srcs = [
+        "grpc/gcp/s2a/s2a_context.proto",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":s2a_common_proto",
+    ],
+)
+
+proto_library(
+    name = "s2a_proto",
+    srcs = [
+        "grpc/gcp/s2a/s2a.proto",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":s2a_common_proto",
+        ":s2a_context_proto",
+    ],
+)

--- a/grpc/gcp/s2a/s2a_context.proto
+++ b/grpc/gcp/s2a/s2a_context.proto
@@ -26,7 +26,7 @@ option java_outer_classname = "S2AContextProto";
 option java_package = "io.grpc.s2a.handshaker";
 
 message S2AContext {
-  reserved 5, 7, 8
+  reserved 5, 7, 8;
 
   // The SPIFFE ID from the peer leaf certificate, if present.
   //


### PR DESCRIPTION
Update the bazel build to add targets for the s2a proto files. Fix syntax error in s2a_context.proto.

Fixes #155.