### PR TITLE
Fix minor typos

### DIFF
--- a/grpc/channelz/v1/channelz.proto
+++ b/grpc/channelz/v1/channelz.proto
@@ -552,7 +552,7 @@ message GetSocketRequest {
   int64 socket_id = 1;
 
   // If true, the response will contain only high level information
-  // that is inexpensive to obtain. Fields thay may be omitted are
+  // that is inexpensive to obtain. Fields that may be omitted are
   // documented.
   bool summary = 2;
 }

--- a/grpc/gcp/handshaker.proto
+++ b/grpc/gcp/handshaker.proto
@@ -145,7 +145,7 @@ message StartServerHandshakeReq {
   map<int32, ServerHandshakeParameters> handshake_parameters = 2;
 
   // Bytes in out_frames returned from the peer's HandshakerResp. It is possible
-  // that the peer's out_frames are split into multiple HandshakReq messages.
+  // that the peer's out_frames are split into multiple HandshakeReq messages.
   bytes in_bytes = 3;
 
   // (Optional) Local endpoint information of the connection to the client,

--- a/grpc/reflection/v1alpha/reflection.proto
+++ b/grpc/reflection/v1alpha/reflection.proto
@@ -92,7 +92,7 @@ message ServerReflectionResponse {
     // that were previously sent in response to earlier requests in the stream.
     FileDescriptorResponse file_descriptor_response = 4;
 
-    // This message is used to answer all_extension_numbers_of_type requst.
+    // This message is used to answer all_extension_numbers_of_type request.
     ExtensionNumberResponse all_extension_numbers_response = 5;
 
     // This message is used to answer list_services request.


### PR DESCRIPTION
Fix three typos, related to https://github.com/protocolbuffers/protobuf/pull/17682 and https://github.com/grpc/grpc-go/pull/7487.