### PR TITLE
binary logging: clarify call cred header behavior, and fix typo

### DIFF
--- a/grpc/binlog/v1/binarylog.proto
+++ b/grpc/binlog/v1/binarylog.proto
@@ -162,7 +162,7 @@ message Message {
 // A list of metadata pairs, used in the payload of client header,
 // server header, and server trailer.
 // Implementations may omit some entries to honor the header limits
-// of GRPC_BINARY_LOG_CONFIG.
+// of GRPC_BINARY_LOG_FILTER.
 //
 // Header keys added by gRPC are omitted. To be more specific,
 // implementations will not log the following entries, and this is
@@ -172,7 +172,9 @@ message Message {
 //   or keys like 'lb-token'
 // - transport specific entries, including but not limited to:
 //   ':path', ':authority', 'content-encoding', 'user-agent', 'te', etc
-// - entries added for call credentials
+// - entries added for call credentials (on client side, excludes all
+//   such headers; on server side, excludes only the "authorization"
+//   header)
 //
 // Implementations must always log grpc-trace-bin if it is present.
 // Practically speaking it will only be visible on server side because

--- a/grpc/binlog/v1alpha/binarylog.proto
+++ b/grpc/binlog/v1alpha/binarylog.proto
@@ -119,7 +119,7 @@ message Message {
 // A list of metadata pairs, used in the payload of CLIENT_INIT_METADATA,
 // SERVER_INIT_METADATA and TRAILING_METADATA
 // Implementations may omit some entries to honor the header limits
-// of GRPC_BINARY_LOG_CONFIG.
+// of GRPC_BINARY_LOG_FILTER.
 // 
 // Implementations will not log the following entries, and this is
 // not to be treated as a truncation:
@@ -127,7 +127,9 @@ message Message {
 //   that begin with 'grpc-' or keys like 'lb-token'
 // - transport specific entries, including but not limited to:
 //   ':path', ':authority', 'content-encoding', 'user-agent', 'te', etc
-// - entries added for call credentials
+// - entries added for call credentials (on client side, excludes all
+//   such headers; on server side, excludes only the "authorization"
+//   header)
 message Metadata {
   repeated MetadataEntry entry = 1 [deprecated = true];
 }


### PR DESCRIPTION
As per https://github.com/grpc/proposal/pull/563.

b/506151077